### PR TITLE
Substitute screen with dtach in headless builds

### DIFF
--- a/patches/headless/conf
+++ b/patches/headless/conf
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+# Author: Anton Pyrogovskyi <anton@turnkeylinux.org> (c) 2015
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get -y \
+    -o DPkg::Options::=--force-confdef \
+    -o DPkg::Options::=--force-confold \
+    install dtach
+

--- a/patches/headless/overlay/root/.profile.d/turnkey-init-fence
+++ b/patches/headless/overlay/root/.profile.d/turnkey-init-fence
@@ -1,4 +1,1 @@
-BIN=/usr/lib/inithooks/bin
-$BIN/screen_session.py /bin/bash -c "turnkey-init && (chmod -x /root/.profile.d/turnkey-init-fence; [ -x /etc/init.d/turnkey-init-fence ] && (update-rc.d turnkey-init-fence remove; /etc/init.d/turnkey-init-fence stop))"
-
-exit
+/usr/bin/dtach -A /root/.inithooks.dtach -Ez /bin/bash -c "turnkey-init && (chmod -x /root/.profile.d/turnkey-init-fence; [ -x /etc/init.d/turnkey-init-fence ] && (update-rc.d turnkey-init-fence remove; /etc/init.d/turnkey-init-fence stop))"


### PR DESCRIPTION
https://github.com/turnkeylinux/common/pull/54 is the permanent version of this temporary hack.