### PR TITLE
Added buildtasks script to apply patch to appliance during ISO build

### DIFF
--- a/bt-iso-patched
+++ b/bt-iso-patched
@@ -1,0 +1,101 @@
+#!/bin/bash -e
+# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $(basename $0) [ --publish ] appname /path/to/patch
+Builds appliance appname (e.g., core) ISO
+
+Options::
+
+    --publish               publish iso, release files and tklbam profile
+
+Environment::
+
+    BT_DEBUG                turn on debugging
+EOF
+exit 1
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --help|-h )    usage;;
+        --publish)     publish="yes";;
+        *)             if [ -n "$appname" ]; then if [ -n "$patch" ]; then usage; else patch=$1; fi else appname=$1; fi ;;
+    esac
+    shift
+done
+
+[ -n "$appname" ] || usage
+[ -n "$patch" ] || usage
+[ -n "$publish" ] || warning "--publish was not specified"
+[ -n "$BT_DEBUG" ] && set -x
+
+export BT=$(dirname $(readlink -f $0))
+export BT_CONFIG=$BT/config
+. $BT_CONFIG/common.cfg
+. $BT_CONFIG/build.cfg
+
+if [ ! -e $BT_PRODUCTS/$appname ]; then
+    cd $BT_PRODUCTS
+    git clone https://github.com/turnkeylinux-apps/$appname.git
+    cd $BT_PRODUCTS/$appname
+else
+    cd $BT_PRODUCTS/$appname
+    git pull
+fi
+
+deck -D build/root.sandbox || true
+make clean || true
+make root.patched || true
+
+tklpatch-apply build/root.patched $patch || true
+make || true
+
+if [ ! -e build/product.iso ]; then
+    if [ -z "$BT_DEBUG" ]; then
+        deck -D build/root.sandbox >/dev/null 2>&1 || true
+        make clean >/dev/null 2>&1 || true
+    fi
+    fatal "build failed..."
+fi
+
+mkdir -p $BT_ISOS
+$BT/bin/iso-release --force $BT_ISOS
+
+patchname=`basename $patch`
+patchname=${patchname%%.*}
+if [[ $patchname != *$appname* ]]; then
+    patchname=${appname}-$patchname
+fi
+name=$(cat build/root.patched/etc/turnkey_version)
+namepatched=${name/$appname/$patchname}
+
+mv $BT_ISOS/$name.iso $BT_ISOS/$namepatched.iso
+mv $BT_ISOS/$name.iso.sig $BT_ISOS/$namepatched.iso.sig
+mv $BT_ISOS/$name.manifest $BT_ISOS/$namepatched.manifest
+mv $BT_ISOS/$name.changelog $BT_ISOS/$namepatched.changelog
+[ -e $BT_ISOS/$name.log ] && mv $BT_ISOS/$name.log $BT_ISOS/$namepatched.log
+[ -e $BT_ISOS/$name.tklbam ] && mv $BT_ISOS/$name.tklbam $BT_ISOS/$namepatched.tklbam
+
+if [ "$publish" == "yes" ]; then
+    $BT/bin/iso-publish $BT_ISOS/$namepatched.iso
+fi
+
+if [ -z "$BT_DEBUG" ]; then
+    deck -D build/root.sandbox
+    make clean
+fi
+


### PR DESCRIPTION
Here is the buildtasks script that I created to apply a patch to an appliance while building an ISO as referenced in https://www.turnkeylinux.org/blog/14.0-optimized-builds-pt2-proxmox-opennode-docker#comment-24370. I changed it from the comments to apply the patch to root.patched since I had some trouble with getting the root.sandbox to overlay when installing the final ISO. Let me know if you have any questions.
