### PR TITLE
revert openstack builds to sysvinit for now

### DIFF
--- a/patches/openstack/conf
+++ b/patches/openstack/conf
@@ -9,7 +9,10 @@ install() {
 }
 
 # install useful packages
-install ebsmount
+install ebsmount sysvinit-core systemd-shim
+
+# remove systemd (sysvinit used in container)
+dpkg --purge systemd-sysv systemd || true
 
 # support hot-plugging of attached volumes
 echo "acpiphp" >> /etc/modules


### PR DESCRIPTION
OpenStack testing only done in a nested virtualisation environment (within Proxmox). Although it seems that SystemD should work fine; we were unable to get it working so reverted to SySVInit until someone else can test and confirm if it's needed or not...