### PR TITLE
Resize the root partition before resizing the root filesystem

### DIFF
--- a/patches/ec2/conf
+++ b/patches/ec2/conf
@@ -8,7 +8,7 @@ install() {
         install $@
 }
 
-install hubclient ebsmount sudo
+install hubclient ebsmount sudo parted gdisk
 
 # grub tweaks
 DEFAULT=/etc/default/grub

--- a/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/25ec2-resizerootpart
+++ b/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/25ec2-resizerootpart
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Author: Anton Pyrogovskyi <anton@turnkeylinux.org>
+
+[ -n "$_TURNKEY_INIT" ] && exit 0
+
+sgdisk -v /dev/xvda | grep -q "Problem: The secondary header's self-pointer indicates that it doesn't reside"
+
+[ $? -eq 0 ] || exit 0
+
+echo 'Backing up the GPT.'
+sgdisk -b /var/tmp/gpt.bak /dev/xvda
+
+sgdisk -e -d 2 -n 2:0:0 -c 2:rootfs -t 2:8300 /dev/xvda
+
+if [ $? -ne 0 ]; then
+    echo 'Something went wrong, rolling back GPT.'
+    sgdisk -l /var/tmp/gpt.bak /dev/xvda
+fi
+
+partprobe

--- a/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/25ec2-resizerootpart
+++ b/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/25ec2-resizerootpart
@@ -3,18 +3,21 @@
 
 [ -n "$_TURNKEY_INIT" ] && exit 0
 
-sgdisk -v /dev/xvda | grep -q "Problem: The secondary header's self-pointer indicates that it doesn't reside"
+DEV=/dev/xvda
+
+sgdisk -v $DEV | grep -q "Problem: The secondary header's self-pointer indicates that it doesn't reside"
 
 [ $? -eq 0 ] || exit 0
 
 echo 'Backing up the GPT.'
-sgdisk -b /var/tmp/gpt.bak /dev/xvda
+sgdisk -b /var/tmp/gpt.bak $DEV
 
-sgdisk -e -d 2 -n 2:0:0 -c 2:rootfs -t 2:8300 /dev/xvda
+FSCT=$( sgdisk -i 2 $DEV | grep 'First sector' | cut -d' ' -f3 )
+sgdisk -e -d 2 -n 2:$FSCT:0 -c 2:rootfs -t 2:8300 $DEV
 
 if [ $? -ne 0 ]; then
     echo 'Something went wrong, rolling back GPT.'
-    sgdisk -l /var/tmp/gpt.bak /dev/xvda
+    sgdisk -l /var/tmp/gpt.bak $DEV
 fi
 
 partprobe


### PR DESCRIPTION
I created this as a separate inithook, but I'm not sure about the name/numbering. Parted is needed for ```partprobe```, otherwise we could do it with ```sgdisk``` alone.

Recreating the partition changes its GUID. This has not proven to be an issue during my tests, however if Parted's ```resize``` is used it retains the GUID. Can't use ```parted``` alone — there is no way to make it fix the GPT non-interactively without getting into something like ```expect``` and frankly, I'd prefer we didn't.

Resolves https://github.com/turnkeylinux/tracker/issues/536