### PR TITLE
Ensure sudoadmin is enabled on rootfs of EC2 builds, disabled when deploying to the Hub

### DIFF
--- a/patches/ec2/conf
+++ b/patches/ec2/conf
@@ -20,3 +20,6 @@ sed -i 's/^#\(GRUB_DISABLE_RECOVERY\)/\1/;' $DEFAULT
 # make sure images are world readable
 chmod 644 /var/lib/inithooks/turnkey-init-fence/htdocs/*.png
 
+# enable sudoadmin in rootfs
+turnkey-sudoadmin on --disable-setpass
+

--- a/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/28ec2-sudoadmin
+++ b/patches/ec2/overlay/usr/lib/inithooks/firstboot.d/28ec2-sudoadmin
@@ -2,9 +2,11 @@
 
 [ -n "$_TURNKEY_INIT" ] && exit 0
 
-# exit if server is registered with hub
-grep -q SERVERID= /var/lib/hubclient/server.conf >/dev/null 2>&1 && exit 0
-
-# non-hub launch, enable turnkey-sudoadmin
-sed -i "s/^SUDOADMIN=.*/SUDOADMIN=true/" /etc/default/inithooks
+if grep -q SERVERID= /var/lib/hubclient/server.conf >/dev/null 2>&1; then
+    # hub launch, disable sudoadmin
+    sed -i "s/^SUDOADMIN=.*/SUDOADMIN=false/" /etc/default/inithooks
+else
+    # non-hub launch
+    exit 0
+fi
 


### PR DESCRIPTION
Depends on https://github.com/turnkeylinux/inithooks/pull/24