### PR TITLE
EC2 PVM boot fix

### DIFF
--- a/bin/ec2/conf.py
+++ b/bin/ec2/conf.py
@@ -1,14 +1,14 @@
 LOG_LEVEL = 'DEBUG'
 
 KERNELS = {
-    # http://go.alonswartz.org/aws-kernels (pv-grub-hd0_1.04)
-    'us-east-1': {'amd64': 'aki-919dcaf8', 'i386': 'aki-8f9dcae6'},
-    'us-west-1': {'amd64': 'aki-880531cd', 'i386': 'aki-8e0531cb'},
-    'us-west-2': {'amd64': 'aki-fc8f11cc', 'i386': 'aki-f08f11c0'},
-    'sa-east-1': {'amd64': 'aki-5553f448', 'i386': 'aki-5b53f446'},
-    'eu-west-1': {'amd64': 'aki-52a34525', 'i386': 'aki-68a3451f'},
-    'ap-southeast-1': {'amd64': 'aki-503e7402', 'i386': 'aki-ae3973fc'},
-    'ap-southeast-2': {'amd64': 'aki-c362fff9', 'i386': 'aki-cd62fff7'},
-    'ap-northeast-1': {'amd64': 'aki-176bf516', 'i386': 'aki-136bf512'},
+    # http://go.alonswartz.org/aws-kernels (pv-grub-hd00_1.04)
+    'us-east-1': {'amd64': 'aki-499ccb20', 'i386': 'aki-659ccb0c'},
+    'us-west-1': {'amd64': 'aki-920531d7', 'i386': 'aki-960531d3'},
+    'us-west-2': {'amd64': 'aki-e28f11d2', 'i386': 'aki-e68f11d6'},
+    'sa-east-1': {'amd64': 'aki-5153f44c', 'i386': 'aki-5753f44a'},
+    'eu-west-1': {'amd64': 'aki-58a3452f', 'i386': 'aki-5ea34529'},
+    'ap-southeast-1': {'amd64': 'aki-563e7404', 'i386': 'aki-5e3e740c'},
+    'ap-southeast-2': {'amd64': 'aki-3b1d8001', 'i386': 'aki-c162fffb'},
+    'ap-northeast-1': {'amd64': 'aki-196bf518', 'i386': 'aki-1f6bf51e'},
 }
 

--- a/bin/ec2/ebs.py
+++ b/bin/ec2/ebs.py
@@ -59,7 +59,7 @@ def usage(e=None):
 
 def main():
     try:
-        l_opts = ["help", "copy", "publish", "marketplace", "name="]
+        l_opts = ["help", "copy", "publish", "marketplace", "pvmregister", "name="]
         opts, args = getopt.gnu_getopt(sys.argv[1:], "h", l_opts)
     except getopt.GetoptError, e:
         usage(e)
@@ -68,6 +68,7 @@ def main():
     copy = False
     publish = False
     marketplace = False
+    pvmregister = False
     for opt, val in opts:
         if opt in ('-h', '--help'):
             usage()
@@ -83,6 +84,9 @@ def main():
 
         if opt == "--marketplace":
             marketplace = True
+
+        if opt == "--pvmregister":
+            pvmregister = True
 
     if len(args) != 1:
         usage("incorrect number of arguments")
@@ -107,6 +111,12 @@ def main():
 
     log.info(ami_name)
     log.important(' '.join([ami_id, arch, region]))
+
+    if pvmregister:
+        ami_id, ami_name = register(snapshot_id, region, arch, pvm=True)
+
+        log.info(ami_name + ' (PVM)')
+        log.important(' '.join([ami_id, arch, region, '(PVM)']))
 
     if publish:
         share_public(ami_id, region)

--- a/bt-ec2
+++ b/bt-ec2
@@ -26,6 +26,7 @@ Options::
     --marketplace       - if set, image will be shared for marketplace
     --secupdates        - install security updates before building image
     --pvmshim           - apply paravirtual shim so snapshot is pvm compat.
+    --pvmregister       - register pvm-virtualized snapshot, too
 
 Environment::
 
@@ -44,6 +45,7 @@ while [ "$1" != "" ]; do
         --publish)     ebs_opts+="$1 "; publish="yes";;
         --secupdates)  secupdates="yes";;
         --pvmshim)     pvmshim="yes";;
+        --pvmregister) ebs_opts+="$1 ";;
         *)             if [ -n "$appname" ]; then usage; else appname=$1; fi ;;
     esac
     shift


### PR DESCRIPTION
The resulting AMI gives off bogus error messages on boot I couldn't find a way to avoid:

```
"main" "root=/dev/sda" "ro" "4"
vbd 2048 is hd0
******************* BLKFRONT for device/vbd/2048 **********
backend at /local/domain/0/backend/vbd/2737/2048
Failed to read /local/domain/0/backend/vbd/2737/2048/feature-barrier.
Failed to read /local/domain/0/backend/vbd/2737/2048/feature-flush-cache.
20971520 sectors of 512 bytes
**************************
vbd 2051 is hd1
******************* BLKFRONT for device/vbd/2051 **********
backend at /local/domain/0/backend/vbd/2737/2051
Failed to read /local/domain/0/backend/vbd/2737/2051/feature-barrier.
Failed to read /local/domain/0/backend/vbd/2737/2051/feature-flush-cache.
1835008 sectors of 512 bytes
**************************
vbd 2064 is hd2
******************* BLKFRONT for device/vbd/2064 **********
backend at /local/domain/0/backend/vbd/2737/2064
Failed to read /local/domain/0/backend/vbd/2737/2064/feature-barrier.
Failed to read /local/domain/0/backend/vbd/2737/2064/feature-flush-cache.
312705024 sectors of 512 bytes
**************************
Booting '3.16.0-4-amd64'
root (hd0,1)
Filesystem type is ext2fs, partition type 0x83
kernel /boot/vmlinuz-3.16.0-4-amd64 root=/dev/xvda2 ro
initrd /boot/initrd.img-3.16.0-4-amd64
============= Init TPM Front ================
Tpmfront:Error Unable to read device/vtpm/0/backend-id during tpmfront initialization! error = E
NOENT
Tpmfront:Info Shutting down tpmfront
close blk: backend=/local/domain/0/backend/vbd/2737/2048 node=device/vbd/2048
close blk: backend=/local/domain/0/backend/vbd/2737/2051 node=device/vbd/2051
close blk: backend=/local/domain/0/backend/vbd/2737/2064 node=device/vbd/2064
```

Boots fine though.