### PR TITLE
Cloud-init

### DIFF
--- a/patches/cloud/conf
+++ b/patches/cloud/conf
@@ -9,7 +9,13 @@ install() {
 }
 
 # install cloud required packages
-install ec2metadata
+install ec2metadata cloud-init
+
+# disable cloud-init on boot
+for i in init config final init-local; do
+    update-rc.d cloud-$i disable
+    systemctl disable cloud-$i.service
+done
 
 # copy mntbind inithook in everyboot
 INITHOOKS=/usr/lib/inithooks

--- a/patches/cloud/overlay/etc/cloud/cloud.cfg
+++ b/patches/cloud/overlay/etc/cloud/cloud.cfg
@@ -1,0 +1,54 @@
+# this is done by inithooks
+disable_root: false
+preserve_hostname: true
+
+cloud_init_modules:
+ - migrator
+ - bootcmd
+ - write-files
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - ca-certs
+ - rsyslog
+ - users-groups
+
+cloud_config_modules:
+ - emit_upstart
+ - mounts
+ - ssh-import-id
+ - locale
+ - set-passwords
+ - grub-dpkg
+ - apt-pipelining
+ - apt-configure
+ - package-update-upgrade-install
+ - landscape
+ - timezone
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - disable-ec2-metadata
+ - runcmd
+ - byobu
+
+cloud_final_modules:
+ - rightscale_userdata
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+ - power-state-change
+
+system_info:
+   distro: debian
+   paths:
+      cloud_dir: /var/lib/cloud/
+      templates_dir: /etc/cloud/templates/
+      upstart_dir: /etc/init/
+   package_mirrors:
+     - arches: [default]
+       failsafe:
+         primary: http://ftp.debian.org/debian

--- a/patches/cloud/overlay/usr/lib/inithooks/firstboot.d/25ec2-userdata
+++ b/patches/cloud/overlay/usr/lib/inithooks/firstboot.d/25ec2-userdata
@@ -27,14 +27,18 @@ class TempFile(file):
 def main():
     userdata = ec2metadata.get('user-data')
 
-    if userdata and userdata.startswith("#!"):
-        fh = TempFile(prefix="ec2userdata")
-        fh.writelines(userdata)
-        fh.close()
+    if userdata:
+        if userdata.startswith('#!'):
+            fh = TempFile(prefix="ec2userdata")
+            fh.writelines(userdata)
+            fh.close()
 
-        os.chmod(fh.path, 0750)
-        executil.system(fh.path)
-        print "# executed ec2 user-data script"
+            os.chmod(fh.path, 0750)
+            executil.system(fh.path)
+            print '# executed ec2 user-data script'
+        else:
+            print '# unknown userdata format - calling cloud-init for help'
+            executil.system('cloud-init init')
 
 if __name__ == "__main__":
     main()

--- a/patches/ec2/overlay/etc/cloud/cloud.cfg.d/90_dpkg.cfg
+++ b/patches/ec2/overlay/etc/cloud/cloud.cfg.d/90_dpkg.cfg
@@ -1,0 +1,3 @@
+# to update this file, run dpkg-reconfigure cloud-init
+datasource_list: [ Ec2, None ]
+


### PR DESCRIPTION
If inithooks does not recognize the usual shebang (`#!`), it passes the data to cloud-init. This allows us to parse all the other [formats](http://cloudinit.readthedocs.io/en/latest/topics/format.html). If the userdata is the usual format with a shebang, cloud-init never gets called.

This has not been tested for cloud providers other than EC2.
