### PR TITLE
Azure build

### DIFF
--- a/bin/vhd-bundle
+++ b/bin/vhd-bundle
@@ -47,8 +47,10 @@ name=$(basename $rootfs .rootfs)
 
 # image size consts.
 
+# made default size smaller for testing
+# azure docs recommend disabling LVM
 info "creating raw image ($VM_SIZE sparse) and partitions"
-qemu-img create -f raw $rootfs.raw 4G
+qemu-img create -f raw $rootfs.raw 4G # made default size smaller for testing
 parted --script $rootfs.raw mklabel msdos
 parted --script -- $rootfs.raw mkpart primary 512M 3512M
 parted --script -- $rootfs.raw set 1 boot on
@@ -75,10 +77,6 @@ mount --rbind --make-rslave /proc $rootfs.fs/proc
 info "installing and configuring grub"
 grubcfg=$rootfs.fs/boot/grub/grub.cfg
 
-# remove / add executable perm to os-prober to stop duplicate grub entries
-chroot $rootfs.fs chmod -x /etc/grub.d/30_os-prober
-chroot $rootfs.fs grub-mkconfig -o /boot/grub/grub.cfg
-chroot $rootfs.fs chmod +x /etc/grub.d/30_os-prober
 
 devicemap=$rootfs.fs/boot/grub/device.map
 
@@ -86,15 +84,7 @@ cat > $devicemap <<EOF
 (hd0)	$loopdev
 EOF
 
-chroot $rootfs.fs grub-mkconfig /boot/grub/grub.cfg
-grub-install --force --modules='part_msdos ext2 search_fs_uuid' --root-directory=$rootfs.fs $loopdev
-
 UUID=$(blkid -o value -s UUID /dev/mapper/`basename $loopdev`p1)
-
-info "tweaking grub settings"
-sed -i "/loopback/d; /set root=(loop/d; s|\(root=\).* ro|\1UUID=$UUID ro dolvm|" $grubcfg
-#remove temp grub/device.map 
-rm -f $devicemap
 
 info "creating fstab"
 fstab="$rootfs.fs/etc/fstab"
@@ -102,7 +92,19 @@ fstab="$rootfs.fs/etc/fstab"
 echo -e "proc\t\t\t/proc\tproc\tnodev,noexec,nosuid\t0\t0" > $fstab
 echo -e "UUID=$UUID\t/\text4\tdefaults\t0\t2" >> $fstab
 
-#tklpatch-apply $rootfs $BT/patches/azure
+tklpatch-apply $rootfs $BT/patches/azure
+
+grub-install --force --modules='part_msdos ext2 search_fs_uuid' --root-directory=$rootfs.fs $loopdev
+
+# remove / add executable perm to os-prober to stop duplicate grub entries
+chroot $rootfs.fs chmod -x /etc/grub.d/30_os-prober
+chroot $rootfs.fs grub-mkconfig -o /boot/grub/grub.cfg
+chroot $rootfs.fs chmod +x /etc/grub.d/30_os-prober
+
+info "tweaking grub settings"
+sed -i "/loopback/d; /set root=(loop/d; s|\(root=\).* ro|\1UUID=$UUID ro dolvm|" $grubcfg
+#remove temp grub/device.map 
+rm -f $devicemap
 
 info "umounting the jumble..."
 umount $rootfs.fs/proc
@@ -111,9 +113,17 @@ umount $rootfs.fs/dev
 umount $rootfs.fs/
 rmdir $rootfs.fs
 
-info "converting raw image to vhd"
+info "resizing raw image (to align to 1MB)"
 #qemu-img convert -f raw $rootfs.raw -O vmdk -o compat6 $name.vmdk
-qemu-img convert -f raw $rootfs.raw -O vpc -o subformat=fixed $name.vhd
+MB=$((1024*1024))
+old_size=$(qemu-img info -f raw $rootfs.raw | sed -r -n "/virtual/{s/.*\(([0-9]+) bytes.*/\1/p}")
+new_size=$((($old_size/$MB+1)*$MB))
+qemu-img resize -f raw $rootfs.raw $new_size
+
+info "converting raw image to vhd"
+qemu-img convert -f raw $rootfs.raw -O vpc -o subformat=fixed,force_size $name.vhd -p
+
+
 
 info "cleaning up"
 kpartx -d /dev/mapper/`basename $loopdev`p1

--- a/bin/vhd-bundle
+++ b/bin/vhd-bundle
@@ -1,0 +1,144 @@
+#!/bin/bash -e
+# depends: qemu grub2 parted kpartx zip ovftool
+# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $0 rootfs
+Bundles rootfs into VHD optimized builds
+
+Arguments::
+
+    rootfs          - root filesystem path
+
+Environment::
+
+    VM_URL        - Product URL ($VM_URL)
+    VM_MEMORY     - Amount of memory - integer ($VM_MEMORY)
+    VM_FULLNAME   - Display name of image ($VM_FULLNAME)
+    VM_GUESTOS    - Guest OS of image ($VM_GUESTOS)
+
+EOF
+exit 1
+}
+
+if [[ "$#" != "1" ]]; then
+    usage
+fi
+
+rootfs=$1
+name=$(basename $rootfs .rootfs)
+
+[ -n "$VM_URL" ] || fatal "VM_URL not set"
+[ -n "$VM_MEMORY" ] || fatal "VM_MEMORY not set"
+[ -n "$VM_FULLNAME" ] || fatal "VM_FULLNAME not set"
+[ -n "$VM_GUESTOS" ] || fatal "VM_GUESTOS not set"
+
+# image size consts.
+
+info "creating raw image ($VM_SIZE sparse) and partitions"
+qemu-img create -f raw $rootfs.raw 4G
+parted --script $rootfs.raw mklabel msdos
+parted --script -- $rootfs.raw mkpart primary 512M 3512M
+parted --script -- $rootfs.raw set 1 boot on
+
+info "setting up loop device"
+loopdev=$(losetup --show -f $rootfs.raw)
+kpartx -as $loopdev
+
+
+info "creating filesystem"
+mkfs.ext4 /dev/mapper/$(basename $loopdev)p1
+
+looproot=$(losetup --show -f /dev/mapper/`basename $loopdev`p1)
+mkdir $rootfs.fs
+mount $looproot $rootfs.fs
+rsync -a -t -r -S -I -H $rootfs/ $rootfs.fs
+
+
+info "mount binding dev and proc"
+mount --rbind --make-rslave /dev $rootfs.fs/dev
+mount --rbind --make-rslave /sys $rootfs.fs/sys
+mount --rbind --make-rslave /proc $rootfs.fs/proc
+
+info "installing and configuring grub"
+grubcfg=$rootfs.fs/boot/grub/grub.cfg
+
+# remove / add executable perm to os-prober to stop duplicate grub entries
+chroot $rootfs.fs chmod -x /etc/grub.d/30_os-prober
+chroot $rootfs.fs grub-mkconfig -o /boot/grub/grub.cfg
+chroot $rootfs.fs chmod +x /etc/grub.d/30_os-prober
+
+devicemap=$rootfs.fs/boot/grub/device.map
+
+cat > $devicemap <<EOF
+(hd0)	$loopdev
+EOF
+
+chroot $rootfs.fs grub-mkconfig /boot/grub/grub.cfg
+grub-install --force --modules='part_msdos ext2 search_fs_uuid' --root-directory=$rootfs.fs $loopdev
+
+UUID=$(blkid -o value -s UUID /dev/mapper/`basename $loopdev`p1)
+
+info "tweaking grub settings"
+sed -i "/loopback/d; /set root=(loop/d; s|\(root=\).* ro|\1UUID=$UUID ro dolvm|" $grubcfg
+#remove temp grub/device.map 
+rm -f $devicemap
+
+info "creating fstab"
+fstab="$rootfs.fs/etc/fstab"
+
+echo -e "proc\t\t\t/proc\tproc\tnodev,noexec,nosuid\t0\t0" > $fstab
+echo -e "UUID=$UUID\t/\text4\tdefaults\t0\t2" >> $fstab
+
+#tklpatch-apply $rootfs $BT/patches/azure
+
+info "umounting the jumble..."
+umount $rootfs.fs/proc
+grep $rootfs.fs/sys /proc/mounts | cut -f2 -d" " | sort -r | xargs umount -n
+umount $rootfs.fs/dev
+umount $rootfs.fs/
+rmdir $rootfs.fs
+
+info "converting raw image to vhd"
+#qemu-img convert -f raw $rootfs.raw -O vmdk -o compat6 $name.vmdk
+qemu-img convert -f raw $rootfs.raw -O vpc -o subformat=fixed $name.vhd
+
+info "cleaning up"
+kpartx -d /dev/mapper/`basename $loopdev`p1
+losetup -d $loopdev
+
+info "setting up image directory"
+mkdir $name
+mv $name.vhd $name/
+
+cat > $name/README.txt <<EOF
+For virtualization specific documentation, please refer to:
+http://www.turnkeylinux.org/docs/virtualization
+EOF
+
+chown -R root:root $name
+chmod 600 $name/*
+chmod 644 $name/$name.vhd
+
+info "generating vhd zip"
+zip -r -T $name-vhd.zip $name
+
+
+if [ -z "$BT_DEBUG" ]; then
+    info "performing final cleanup"
+    rm -rf $name
+    #rm -f $rootfs.raw
+fi
+

--- a/bt-vhd
+++ b/bt-vhd
@@ -1,0 +1,122 @@
+#!/bin/bash -e
+# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $(basename $0) [--publish] appname
+Converts appliance appname (e.g., core) to vhd
+
+Options::
+
+    --publish           - if set, image and meta files will be published
+
+Environment::
+
+    BT_DEBUG            - turn on debugging
+EOF
+exit 1
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --help|-h )  usage;;
+        --publish)   publish="yes";;
+        *)           if [ -n "$appname" ]; then usage; else appname=$1; fi ;;
+    esac
+    shift
+done
+
+[ -n "$appname" ] || usage
+[ -n "$publish" ] || warning "--publish was not specified"
+
+[ -n "$BT_DEBUG" ] && set -x
+
+export BT=$(dirname $(readlink -f $0))
+export BT_CONFIG=$BT/config
+. $BT_CONFIG/common.cfg
+. $BT_CONFIG/build.cfg
+
+O=$BT_BUILDS/vm
+mkdir -p $O
+
+[ -n "$BT_VERSION" ] || fatal "BT_VERSION not set"
+
+if [ "$publish" == "yes" ]; then
+    [ -n "$BT_PUBLISH_IMGS" ] || fatal "BT_PUBLISH_IMGS not set"
+    [ -n "$BT_PUBLISH_META" ] || fatal "BT_PUBLISH_META not set"
+fi
+
+export VM_URL="http://www.turnkeylinux.org/$appname"
+export VM_FULLNAME="TURNKEY $(echo $appname | tr [a-z] [A-Z] | sed s'/-/ /g')"
+
+case "$appname" in
+    canvas)           export VM_MEMORY=1024 ;;
+    gitlab)           export VM_MEMORY=1024 ;;
+    jenkins)          export VM_MEMORY=1024 ;;
+    odoo)             export VM_MEMORY=1024 ;;
+    tkldev)           export VM_MEMORY=768 ;;
+    moodle)           export VM_MEMORY=768 ;;
+    tomcat-apache)    export VM_MEMORY=768 ;;
+    appengine-java)   export VM_MEMORY=768 ;;
+    *)                export VM_MEMORY=512 ;;
+esac
+
+if $(echo $BT_VERSION | grep -q squeeze-i386); then guestos="debian6"; fi
+if $(echo $BT_VERSION | grep -q squeeze-amd64); then guestos="debian6-64"; fi
+if $(echo $BT_VERSION | grep -q wheezy-i386); then guestos="debian7"; fi
+if $(echo $BT_VERSION | grep -q wheezy-amd64); then guestos="debian7-64"; fi
+if $(echo $BT_VERSION | grep -q jessie-i386); then guestos="debian8"; fi
+if $(echo $BT_VERSION | grep -q jessie-amd64); then guestos="debian8-64"; fi
+[ -n "$guestos" ] || fatal "guestos could not be determined"
+export VM_GUESTOS="$guestos"
+
+isofile=turnkey-$appname-$BT_VERSION.iso
+name=turnkey-$appname-$BT_VERSION
+rootfs=$name.rootfs
+cdroot=$name.cdroot
+
+$BT/bin/iso-download $BT_ISOS $BT_VERSION $appname
+$BT/bin/iso-verify $BT_ISOS $BT_VERSION $appname
+
+cd $O
+tklpatch-extract-iso $BT_ISOS/$isofile
+tklpatch-apply $rootfs $BT/patches/headless
+tklpatch-apply $rootfs $BT/patches/azure
+$BT/bin/rootfs-cleanup $rootfs
+
+$BT/bin/aptconf-tag $rootfs vm
+
+bash -exv $BT/bin/vhd-bundle $O/$rootfs
+
+$BT/bin/generate-signature $O/$name.vhd
+
+# publish if specified
+if [ "$publish" == "yes" ]; then
+    export PUBLISH_DEST=${BT_PUBLISH_IMGS}/vmdk/
+    $BT/bin/publish-files $O/$name-vmdk.zip
+
+    export PUBLISH_DEST=${BT_PUBLISH_IMGS}/ova/
+    $BT/bin/publish-files $O/$name.ova
+
+    export PUBLISH_DEST=${BT_PUBLISH_META}/
+    $BT/bin/publish-files $O/$name-vmdk.{zip.sig,zip.buildenv}
+    $BT/bin/publish-files $O/$name.{ova.sig,ova.buildenv}
+fi
+
+if [ -z "$BT_DEBUG" ] && ! (mount | grep -q $(basename $rootfs)); then
+    rm -rf $rootfs
+    rm -rf $cdroot
+fi
+

--- a/bt-vhd
+++ b/bt-vhd
@@ -93,12 +93,11 @@ $BT/bin/iso-verify $BT_ISOS $BT_VERSION $appname
 cd $O
 tklpatch-extract-iso $BT_ISOS/$isofile
 tklpatch-apply $rootfs $BT/patches/headless
-tklpatch-apply $rootfs $BT/patches/azure
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs vm
 
-bash -exv $BT/bin/vhd-bundle $O/$rootfs
+$BT/bin/vhd-bundle $O/$rootfs
 
 $BT/bin/generate-signature $O/$name.vhd
 

--- a/patches/azure/conf
+++ b/patches/azure/conf
@@ -10,9 +10,11 @@ install() {
 
 
 
+# Added recommended default grub settings
 DEFAULT=/etc/default/grub
 sed -i 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 rootdelay=30"/' $DEFAULT 
 
+# Should we be adding these repos or replacing the normal debian repos?
 cat <<EOF >> /etc/apt/sources.list.d/azure.list
 deb http://debian-archive.trafficmanager.net/debian jessie-backports main
 deb-src http://debian-archive.trafficmanager.net/debian jessie-backports main
@@ -26,5 +28,7 @@ gpg -a --export 06EA49E9A86CAD7F | apt-key add -
 apt-key update
 
 install waagent
-waagent -force -deprovision
+
+waagent -force -deprovision -verbose
+
 export HISTSIZE=0

--- a/patches/azure/conf
+++ b/patches/azure/conf
@@ -1,0 +1,30 @@
+#!/bin/bash +ex
+
+install() {
+    apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get -y \
+        -o DPkg::Options::=--force-confdef \
+        -o DPkg::Options::=--force-confold \
+        install $@
+}
+
+
+
+DEFAULT=/etc/default/grub
+sed -i 's/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 rootdelay=30"/' $DEFAULT 
+
+cat <<EOF >> /etc/apt/sources.list.d/azure.list
+deb http://debian-archive.trafficmanager.net/debian jessie-backports main
+deb-src http://debian-archive.trafficmanager.net/debian jessie-backports main
+deb http://debian-archive.trafficmanager.net/debian-azure jessie main
+deb-src http://debian-archive.trafficmanager.net/debian-azure jessie main
+EOF
+
+gpg --keyserver pgpkeys.mit.edu --recv-key 06EA49E9A86CAD7F
+gpg -a --export 06EA49E9A86CAD7F | apt-key add -
+
+apt-key update
+
+install waagent
+waagent -force -deprovision
+export HISTSIZE=0


### PR DESCRIPTION
Microsoft Azure
===============

It's probably worth noting the bt-vhd and vhd-bundle scripts are copied from
the vm counterparts so there is most likely unnecessary code left over.

Microsoft Azure only supports fixed vhds (vpc) aligned to 1MB. Using
"qemu-img info" and "qemu-img resize" this is trivial. First resize the image
to the next largest 1MB and then convert the raw image to a vpc fixed sized
image and pass "force_size" to assure the image is not padded during
conversion.

"qemu-img convert -o subformat=fixed,force_size ..."

Note a bug in qemu preventing it from maintaining image size between vhd
conversions has been fixed in qemu 2.6. Qemu will need to be updated to convert
raw to azure compatible vhds.


Waagent was running correctly previously however since my most recent commit it
isn't polluting the root console of the vm nor is the vm saying the agent is
running. While I'm not 100% sure I suspect this is because I was previously
(accidently) running the azure patch twice, once directly from the bt-vhd
script and one from within bin/vhd-bundle, during cleaning up I removed the
call from bt-vhd.

Other notes
-----------

- Waagent seems to handle ssh/user accounts on Azure, although I'm unsure of
  how it works as I was never able to login to any of my test machines on
  Azure.

- A few grub options are added to GRUB_DEFAULT, I was unsure of their effect
  and not knowing possible implications either way decided to follow MS's
  advice.

- Azure doesn't support LVM, so LVM is not present azure build code

- Waagent pollutes the TKLDev's root console as well as changes it's hostname,
  nothing destructive that I've noticed though.

- The ethernet interfaces should probably be hotpluggable by default

- The azure cli appears to either auto-update or retrieve avaliable commands
  from microsoft, as I've noticed command names change.