### PR TITLE
update to use .hash (instead of .sig)

### DIFF
--- a/bin/generate-buildenv
+++ b/bin/generate-buildenv
@@ -19,12 +19,12 @@ Print build environment related to target build type
 Targets::
 
     iso         appname
-    vm          path/to/iso.sig
-    ec2         path/to/iso.sig
-    xen         path/to/iso.sig
-    docker      path/to/iso.sig
-    container   path/to/iso.sig
-    openstack   path/to/iso.sig
+    vm          path/to/iso.hash
+    ec2         path/to/iso.hash
+    xen         path/to/iso.hash
+    docker      path/to/iso.hash
+    container   path/to/iso.hash
+    openstack   path/to/iso.hash
 
 EOF
 exit 1
@@ -54,10 +54,10 @@ _common() {
 }
 
 _optimized() {
-    # get sha1 from sig (supports yet-to-be signed iso sigs)
-    sigpath=$1
-    sigsha1=$(grep -A 1 sha1sum $sigpath | tail -n 1 | sed "s/^ *//")
-    echo "$(basename $sigpath) $sigsha1"
+    # get sha1 from hash file (supports yet-to-be signed iso hash files)
+    hashpath=$1
+    hashsha1=$(grep -A 1 sha1sum $hashpath | tail -n 1 | sed "s/^ *//")
+    echo "$(basename $hashpath) $hashsha1"
 
     echo "tklpatch $(dpkg -s tklpatch | grep Version | cut -d ' ' -f 2)"
 }

--- a/bin/iso-publish
+++ b/bin/iso-publish
@@ -54,7 +54,7 @@ for f in $FILES; do
     $BT/bin/publish-files $O/$name.iso
 
     export PUBLISH_DEST=${BT_PUBLISH_META}/
-    $BT/bin/publish-files $O/$name.{changelog,manifest,iso.buildenv,iso.sig}
+    $BT/bin/publish-files $O/$name.{changelog,manifest,iso.buildenv,iso.hash}
 
     if [ -e $O/$name.tklbam/*.tar.gz ]; then
         export PUBLISH_DEST=${BT_PUBLISH_PROFILES}/

--- a/bin/iso-release
+++ b/bin/iso-release
@@ -53,7 +53,7 @@ appname=$(echo $name |sed 's/turnkey-\(.*\)-[0-9].*/\1/')
 
 if [ "$force" == "yes" ]; then
     rm -f $O/$name.iso
-    rm -f $O/$name.iso.sig
+    rm -f $O/$name.iso.hash
     rm -f $O/$name.iso.buildenv
     rm -f $O/$name.manifest
     rm -f $O/$name.changelog
@@ -62,7 +62,7 @@ if [ "$force" == "yes" ]; then
 fi
 
 [ -e $O/$name.iso ] && fatal "$O/$name.iso already exists"
-[ -e $O/$name.iso.sig ] && fatal "$O/$name.iso.sig already exists"
+[ -e $O/$name.iso.hash ] && fatal "$O/$name.iso.hash already exists"
 [ -e $O/$name.iso.buildenv ] && fatal "$O/$name.iso.buildenv already exists"
 [ -e $O/$name.manifest ] && fatal "$O/$name.manifest already exists"
 [ -e $O/$name.changelog ] && fatal "$O/$name.changelog already exists"


### PR DESCRIPTION
Recently the `.sig` file has been updated to instead be a `.hash` file (as it's not really a sign file anymore; the new name is a more accurate description. This PR fixes a few stray issues when building the ISO. 

There will likely be more fixes needed for other build types.