### PR TITLE
added bin/openstack-setup to install mbr pkg

### DIFF
--- a/bin/openstack-setup
+++ b/bin/openstack-setup
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $(basename $0)
+Setup/update system ready for bt-openstack
+
+Environment::
+
+    BT_DEBUG                turn on debugging
+
+EOF
+exit 1
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --help|-h )    usage;;
+        *)             usage;;
+    esac
+    shift
+done
+
+[ -n "$BT_DEBUG" ] && set -x
+
+install() {
+    apt-get -qq update
+    DEBIAN_FRONTEND=noninteractive apt-get -y install $1
+}
+
+if ! which install-mbr >/dev/null; then
+    info "installing mbr"
+    install "mbr"
+fi
+


### PR DESCRIPTION
To produce the new improved `openstack` builds, the `mbr` package must be installed. As a short term workaround, I have created the new `openstack-setup` script. It's essentially just a copy of `docker-setup` but just the relevant bits included. 

IMO, we probably should consider consolidating all the setup requirements (i.e. the contents of docs/setup) into a single setup script which accepts a `build-type` argument. But until then, this should work around the missing `bt-openstack` dependency.