### PR TITLE
Bt clean

### DIFF
--- a/bt-clean
+++ b/bt-clean
@@ -1,0 +1,73 @@
+#!/bin/bash -e
+# Copyright (c) 2017 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $(basename $0) buildtype1 [buildtype2 ...]  appname-version
+Cleans local storage of appname-version appliance of specified buildtype(s)
+
+Can be useful to avoid running out of space when batch processing
+
+Arguments::
+
+    buildtype           - container|openstack|vm|xen
+                          (multiple builds to be space separated)
+
+    appname-version     - e.g., core-14.2-jessie-amd64
+
+Environment::
+
+    BT_DEBUG            - turn on debugging
+EOF
+exit 1
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        iso)         iso=y;;
+        container)   container=y;;
+        openstack)   openstack=y;;
+        vm)          vm=y;;
+        xen)         xen=y;;
+        --help|-h )  usage;;
+        *)           if [ -n "$appver" ]; then usage; else appver=$1; fi ;;
+    esac
+    shift
+done
+
+[ -n "$appver" ] || usage
+[ -n "$BT_DEBUG" ] && set -x
+
+export BT=$(dirname $(readlink -f $0))
+export BT_CONFIG=$BT/config
+. $BT_CONFIG/common.cfg
+
+remove() {
+    rm_app=turnkey-$1
+    rm_build=$2
+    if [ "$rm_build" = "iso" ]; then
+        basepath=$BT_ISOS
+    else
+        basepath=$BT_BUILDS/$rm_build
+    fi
+    rm -rf $basepath/$rm_app*
+}
+
+[ "$iso" = "y" ] && remove $appver iso
+[ "$container" = "y" ] && remove $appver container
+[ "$openstack" = "y" ] && remove $appver openstack
+[ "$vm" = "y" ] && remove $appver vm
+[ "$xen" = "y" ] && remove $appver xen
+

--- a/bt-optimized
+++ b/bt-optimized
@@ -32,7 +32,10 @@ exit 1
 while [ "$1" != "" ]; do
     case $1 in
         --help|-h )  usage;;
-        --publish)   opts="--publish";;
+        --publish)   opts="--publish"; clean="y";; 
+
+        #--clean should ideally be it's own switch, but for now see above line
+
         *)           if [ -n "$appver" ]; then usage; else appver=$1; fi ;;
     esac
     shift
@@ -44,9 +47,13 @@ BT=$(dirname $(readlink -f $0))
 ARCH=$(dpkg --print-architecture)
 
 $BT/bt-vm $opts $appver
+[ "$clean" = "y" ] && $BT/bt-clean vm $appver
 $BT/bt-container $opts $appver
+[ "$clean" = "y" ] && $BT/bt-clean container $appver
 $BT/bt-openstack $opts $appver
+[ "$clean" = "y" ] && $BT/bt-clean openstack $appver
 $BT/bt-xen $opts $appver
+[ "$clean" = "y" ] && $BT/bt-clean xen $appver
 [ "$ARCH" == "amd64" ] && $BT/bt-docker $opts $appver
 
 exit 0

--- a/bt-optimized
+++ b/bt-optimized
@@ -50,8 +50,8 @@ $BT/bt-vm $opts $appver
 [ "$clean" = "y" ] && $BT/bt-clean vm $appver
 $BT/bt-container $opts $appver
 [ "$clean" = "y" ] && $BT/bt-clean container $appver
-$BT/bt-openstack $opts $appver
-[ "$clean" = "y" ] && $BT/bt-clean openstack $appver
+#$BT/bt-openstack $opts $appver
+#[ "$clean" = "y" ] && $BT/bt-clean openstack $appver
 $BT/bt-xen $opts $appver
 [ "$clean" = "y" ] && $BT/bt-clean xen $appver
 [ "$ARCH" == "amd64" ] && $BT/bt-docker $opts $appver


### PR DESCRIPTION
This PR adds a `bt-clean` script. 

`bt-clean` is a simple script to clean up a specific appliance in a specific build. It is generally only useful if you are publishing (otherwise it will delete the build you just created!). It is especially handy if you are doing batch builds using `bt-optimized`.  Hence why it is automatically invoked by `bt-optimized` when the `--publish` switch is specified.

Also I've temporarily commented out the openstack build as it's still not quite ready yet...