### PR TITLE
make bin/vm-bundle more robust

### DIFF
--- a/bin/vm-bundle
+++ b/bin/vm-bundle
@@ -65,10 +65,20 @@ parted --script -- $rootfs.raw mkpart primary $VM_PARTED_LVM
 parted --script -- $rootfs.raw set 1 boot on
 parted --script -- $rootfs.raw set 1 LVM on
 
-info "setting up loop device and LVM"
-kpartx -as $rootfs.raw
-loopdev=$(kpartx -l $rootfs.raw | cut -d' ' -f1)
+info "setting up loop device ($loopdev) and checking that it's mounted"
+loopdev=$(kpartx -avs $rootfs.raw | cut -d' ' -f3)
+for i in {1..11}; do
+    if ls /dev/mapper/$loopdev >/dev/null 2>&1; then
+        info "success - $loopdev is mounted (waited $(( i - 1)) seconds(s))"
+        break
+    elif [ "$i" -eq 11 ]; then
+        fatal "$loopdev is NOT mounted (waited 10 seconds)"
+    else
+        sleep 1
+    fi
+done
 
+info "setting up LVM"
 pvcreate /dev/mapper/$loopdev
 vgcreate $VG /dev/mapper/$loopdev
 lvcreate -L $VM_PARTED_LVM_ROOT -n root $VG
@@ -76,7 +86,7 @@ lvcreate -L $VM_PARTED_LVM_SWAP -n swap_1 $VG
 vgscan
 vgchange -a y
 
-info "creating filesystems (boot, root, swap)"
+info "creating filesystems (root & swap)"
 mkfs.ext4 /dev/mapper/$VG-root
 mkswap /dev/mapper/$VG-swap_1
 
@@ -116,6 +126,7 @@ umount $rootfs.vm/
 info "cleaning up volume groups and mounts"
 vgchange -a n $VG
 kpartx -dv $rootfs.raw
+dmsetup remove_all
 rmdir $rootfs.vm
 rm -f /etc/lvm/backup/$VG
 


### PR DESCRIPTION
This is an addendum to #44 

`bin/vm-bundle` is made more robust by:
- checking for the existence of `$loopdev
  - some builds were failing because `kpartx` was a little slow mounting the img file
  - possibly overly verbose; output could be reduced, but for now the additional feedback may be useful.
- using `dmsetup` to do a final cleanup
  - generally `kpartx` works fine, but on odd occasions I found that it wasn't cleaning up properly afterwards. It doesn't actually cause an issue for that particular build, but can cause issues for future builds.

I also tidied up a reference to boot partition which I'd missed previously.