### PR TITLE
15.0 xen update

### DIFF
--- a/bin/build-tag
+++ b/bin/build-tag
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+cat<<EOF
+Syntax: $0 rootfs tag
+Tag the build within the filesystem with build info
+
+Arguments::
+
+    rootfs      - root filesystem path
+    tag         - the build tag
+EOF
+exit 1
+}
+
+if [[ "$#" != "2" ]]; then
+    usage
+fi
+
+rootfs=$1
+tag=$2
+
+if [[ -z $tag ]]; then
+    tag="iso"
+fi
+
+case $tag in
+    proxmox)
+        unit="lxc"
+    ;;
+    xen)
+        unit="xen"
+    ;;
+    *)
+        # openstack, docker, ec2 and vm
+        unit="default"
+    ;;
+esac
+
+TKL_INFO=$rootfs/var/lib/turnkey-info
+
+rm -rf $TKL_INFO
+mkdir -p $TKL_INFO/inithooks.service
+touch $TKL_INFO/inithooks.service/$unit

--- a/bt-container
+++ b/bt-container
@@ -104,6 +104,7 @@ tklpatch-apply $rootfs $BT/patches/container
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs proxmox
+$BT/bin/build-tag $rootfs proxmox
 
 # bundle proxmox tarball using stupid naming convention
 stupidname="${debianversion}-turnkey-${appname}_${appversion}-1_${arch}"

--- a/bt-docker
+++ b/bt-docker
@@ -105,6 +105,7 @@ tklpatch-apply $rootfs $BT/patches/docker
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs docker
+$BT/bin/build-tag $rootfs docker
 
 # create docker image
 appversion=$(echo $BT_VERSION | cut -d "-" -f 1)

--- a/bt-ec2
+++ b/bt-ec2
@@ -126,6 +126,7 @@ umount -l $rootfs/proc || true
 
 $BT/bin/rootfs-cleanup $rootfs
 $BT/bin/aptconf-tag $rootfs ec2
+$BT/bin/build-tag $rootfs ec2
 $BT/bin/ec2/ebs.py $ebs_opts $rootfs
 $BT/bin/generate-buildenv ec2 $BT_ISOS/$isofile.hash > $O/$name.ec2.buildenv
 

--- a/bt-openstack
+++ b/bt-openstack
@@ -90,6 +90,7 @@ tklpatch-apply $rootfs $BT/patches/openstack
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs openstack
+$BT/bin/build-tag $rootfs openstack
 
 $BT/bin/openstack-bundle $rootfs
 

--- a/bt-openstack-ami
+++ b/bt-openstack-ami
@@ -70,6 +70,7 @@ tklpatch-apply $rootfs $BT/patches/openstack-ami
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs openstack
+$BT/bin/build-tag $rootfs openstack
 
 $BT/bin/openstack-bundle-ami $rootfs
 

--- a/bt-vm
+++ b/bt-vm
@@ -105,6 +105,7 @@ tklpatch-apply $rootfs $BT/patches/vm
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs vm
+$BT/bin/build-tag $rootfs vm
 
 $BT/bin/vm-bundle $O/$rootfs
 

--- a/bt-xen
+++ b/bt-xen
@@ -76,16 +76,24 @@ tklpatch-extract-iso $BT_ISOS/$isofile
 
 tklpatch-apply $rootfs $BT/patches/headless
 
-mount --bind --make-rslave /dev $rootfs/dev
+#mount --bind --make-rslave /dev $rootfs/dev
+mount -t proc proc $rootfs/proc
+mount -t sysfs sys $rootfs/sys
+mount -o bind /dev $rootfs/dev
+
+
 tklpatch-apply $rootfs $BT/patches/xen
 umount $rootfs/dev
+umount $rootfs/sys
+umount $rootfs/proc
 
 $BT/bin/rootfs-cleanup $rootfs
 
 $BT/bin/aptconf-tag $rootfs xen
+$BT/bin/build-tag $rootfs xen
 
 info "creating $name-xen.tar.bz2"
-tar -C $rootfs -jcf $name-xen.tar.bz2 .
+tar --numeric-owner -C $rootfs -jcf $name-xen.tar.bz2 .
 
 $BT/bin/generate-signature $O/$name-xen.tar.bz2
 

--- a/bt-xen
+++ b/bt-xen
@@ -76,16 +76,10 @@ tklpatch-extract-iso $BT_ISOS/$isofile
 
 tklpatch-apply $rootfs $BT/patches/headless
 
-#mount --bind --make-rslave /dev $rootfs/dev
-mount -t proc proc $rootfs/proc
-mount -t sysfs sys $rootfs/sys
-mount -o bind /dev $rootfs/dev
-
+mount --bind --make-rslave /dev $rootfs/dev
 
 tklpatch-apply $rootfs $BT/patches/xen
 umount $rootfs/dev
-umount $rootfs/sys
-umount $rootfs/proc
 
 $BT/bin/rootfs-cleanup $rootfs
 


### PR DESCRIPTION
Adds ``build-tag`` script for adding build information to builds so that the inithooks service (and potentially others) can determine certain information about it's current underlying virtualization.