### PR TITLE
Confconsole autorun - disable on headless builds; run via turnkey-init

### DIFF
--- a/patches/container/overlay/root/.profile.d/turnkey-init-fence
+++ b/patches/container/overlay/root/.profile.d/turnkey-init-fence
@@ -1,1 +1,1 @@
-/usr/bin/dtach -A /root/.inithooks.dtach -Ez /bin/bash -c "TERM=xterm; turnkey-init"
+/usr/bin/dtach -A /root/.inithooks.dtach -Ez /bin/bash -c "TERM=xterm; turnkey-init --full-confconsole"

--- a/patches/ec2/conf
+++ b/patches/ec2/conf
@@ -32,3 +32,10 @@ for user in $additional_users; do
         sed -i "/.ssh/ s|root|home/admin|" $ansible_init
     fi
 done
+
+# init fence now launches confconsole with full options, so autolaunch disabled
+# on other headless builds. However, we want it on Hub builds, except tkldev.
+if [[ "$(turnkey-version --name)" != "tkldev" ]]; then
+    confconsole_auto='/root/.bashrc.d/confconsole-auto'
+    [[ -f "$confconsole_auto" ]] && chmod -x "$confconsole_auto"
+fi

--- a/patches/ec2/conf
+++ b/patches/ec2/conf
@@ -34,8 +34,6 @@ for user in $additional_users; do
 done
 
 # init fence now launches confconsole with full options, so autolaunch disabled
-# on other headless builds. However, we want it on Hub builds, except tkldev.
-if [[ "$(turnkey-version --name)" != "tkldev" ]]; then
-    confconsole_auto='/root/.bashrc.d/confconsole-auto'
-    [[ -f "$confconsole_auto" ]] && chmod -x "$confconsole_auto"
-fi
+# on other headless builds. However, we want it on Hub builds.
+confconsole_auto='/root/.bashrc.d/confconsole-auto'
+[[ -f "$confconsole_auto" ]] && chmod -x "$confconsole_auto"

--- a/patches/headless/conf
+++ b/patches/headless/conf
@@ -7,3 +7,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y \
     -o DPkg::Options::=--force-confold \
     install dtach inithooks
 
+# init fence now launches confconsole with full options, so autolaunch not
+# required, or desired.
+confconsole_auto='/root/.bashrc.d/confconsole-auto'
+[[ -x "$confconsole_auto" ]] && chmod -x "$confconsole_auto"

--- a/patches/headless/overlay/root/.profile.d/turnkey-init-fence
+++ b/patches/headless/overlay/root/.profile.d/turnkey-init-fence
@@ -1,1 +1,1 @@
-/usr/bin/dtach -A /root/.inithooks.dtach -Ez /bin/bash -c "turnkey-init"
+/usr/bin/dtach -A /root/.inithooks.dtach -Ez /bin/bash -c "turnkey-init --full-confconsole"


### PR DESCRIPTION
As per title, these changes are for headless builds.

The `dtach` process can now run `turnkey-init` with the `--full-confconsole` switch (requires inithooks `2.0.1+2+g9bb5dc1` or later), which will launch confconsole in complete mode (i.e. with plugins available and can make other changes).

Also, the default confconsole autostart feature (in `/root/.bashrc.d/`) is disabled, except in Hub builds.

TKLDev has the autostart feature disabled via the [TKLDev conf script](https://github.com/turnkeylinux-apps/tkldev/blob/2ef4caab44ac865a9307c21c83b13d603b30fcf2/conf.d/main#L40-L41) (i.e. TKLDev build code).