### PR TITLE
Also remove /dev/[u]random from postfix chroot on openldap appliance too.

### DIFF
--- a/patches/container/conf
+++ b/patches/container/conf
@@ -56,11 +56,7 @@ sed -i '/REDIRECT_OUTPUT/ s/=.*/=true/g' /etc/default/inithooks
 # clean up unrequired package(s)
 apt-get autoremove -y
 
-# remove postfix /dev/[u]random
-# unless it's openldap because it breaks ldap/postfix integration see issue #855
-# this is permanantly locked in an overlay but cannot be done here because it
-# makes the rootfs itself impossible to remove
-appname="$(turnkey-version | sed 's/^turnkey-\(.*\)-[0-9]\+.[0-9]\+\(rc[0-9]\+\)*-.*-amd64/\1/g')"
-if [[ "$appname" != "openldap" ]]; then
-    rm -rf /var/spool/postfix/dev/{u,}random
-fi
+# remove postfix /dev/[u]random to support unprivileged containers
+# note that it breaks ldap/postfix integration - see issue #855
+# (applyed to openldap too as of v16.1)
+rm -rf /var/spool/postfix/dev/{u,}random


### PR DESCRIPTION
Remove `/dev/[u]random` from postfix chroot on OpenLDAP appliance too for v16.1.

Closes https://github.com/turnkeylinux/tracker/issues/1535.