### PR TITLE
Remove `jitterentropy-rngd` & `acpid` in LXC container builds

### DIFF
--- a/bt-container
+++ b/bt-container
@@ -72,16 +72,14 @@ case "$appname" in
     tkldev)           export ON_MEMORY=0.50 ;;
     moodle)           export ON_MEMORY=0.33 ;;
     tomcat-apache)    export ON_MEMORY=0.33 ;;
-    appengine-java)   export ON_MEMORY=0.33 ;;
     *)                export ON_MEMORY=0.25 ;;
 esac
 
 case "$codename" in
-    squeeze) debianversion="debian-6" ;;
-    wheezy)  debianversion="debian-7" ;;
-    jessie)  debianversion="debian-8" ;;
-    stretch) debianversion="debian-9" ;;
-    buster)  debianversion="debian-10" ;;
+    stretch)    debianversion="debian-9" ;;
+    buster)     debianversion="debian-10" ;;
+    bullseye)   debianversion="debian-11" ;;
+    bookworm)   debianversion="debian-12" ;;
     *)       fatal "debianversion could not be determined" ;;
 esac
 

--- a/patches/container/conf
+++ b/patches/container/conf
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 # Original author: Alon Swartz <alon@turnkeylinux.org> (c) 2012-2013
-# Since modified by: TurnKey Linux (c)2014-2018
+# Since modified by: TurnKey Linux (c)2014-2022
 
 # remove kernel
 ARCH=$(dpkg --print-architecture)
@@ -32,13 +32,11 @@ mv /usr/sbin/update-grub.orig /usr/sbin/update-grub
 # stop auto-secupdates complaining
 mkdir -p /lib/modules
 
-# remove ntp daemon
-dpkg --purge ntp || true
+# remove ntp & jitterentropy daemons
+dpkg --purge ntp jitterentropy-rngd  || true
 
 # disable tklbam fixclock-hook - can't set time in a container (closes #1170)
 chmod -x /etc/tklbam/hooks.d/fixclock
-
-systemctl disable confconsole || true
 
 # remove /etc/fstab - workaround #1139
 rm -rf /etc/fstab

--- a/patches/container/conf
+++ b/patches/container/conf
@@ -33,7 +33,7 @@ mv /usr/sbin/update-grub.orig /usr/sbin/update-grub
 mkdir -p /lib/modules
 
 # remove ntp, jitterentropy & acpi daemons
-dpkg --purge ntp jitterentropy-rngd acpid  || true
+apt-get purge --autoremove -y ntp jitterentropy-rngd acpid  || true
 
 # disable tklbam fixclock-hook - can't set time in a container (closes #1170)
 chmod -x /etc/tklbam/hooks.d/fixclock

--- a/patches/container/conf
+++ b/patches/container/conf
@@ -32,8 +32,8 @@ mv /usr/sbin/update-grub.orig /usr/sbin/update-grub
 # stop auto-secupdates complaining
 mkdir -p /lib/modules
 
-# remove ntp & jitterentropy daemons
-dpkg --purge ntp jitterentropy-rngd  || true
+# remove ntp, jitterentropy & acpi daemons
+dpkg --purge ntp jitterentropy-rngd acpid  || true
 
 # disable tklbam fixclock-hook - can't set time in a container (closes #1170)
 chmod -x /etc/tklbam/hooks.d/fixclock


### PR DESCRIPTION
Remove `jitterentropy-rngd` & `acpid` in LXC container builds, plus some other minor updates and tidy.

closes https://github.com/turnkeylinux/tracker/issues/1636
closes https://github.com/turnkeylinux/tracker/issues/1725