### PR TITLE
Disable systemd-resolved.service (so that it doesn't override resolvconf).

### DIFF
--- a/patches/container/conf
+++ b/patches/container/conf
@@ -38,6 +38,9 @@ apt-get purge --autoremove -y ntp jitterentropy-rngd acpid  || true
 # disable ssh.socket so that sshd runs reliably - closes #1722
 systemctl mask ssh.socket
 
+# disable systemd-resolved.service - closes #1766
+systemctl mask systemd-resolved.service
+
 # disable tklbam fixclock-hook - can't set time in a container (closes #1170)
 chmod -x /etc/tklbam/hooks.d/fixclock
 


### PR DESCRIPTION
closes https://github.com/turnkeylinux/tracker/issues/1766