### PR TITLE
Update bt-iso to work around fab bug (in v17.0).

### DIFF
--- a/bt-iso
+++ b/bt-iso
@@ -45,7 +45,7 @@ done
 [ -n "$appname" ] || usage
 [ -n "$BT_DEBUG" ] && set -x
 
-REQ_FAB_V=0.8
+REQ_FAB_V=1.0.2
 REQ_DBOOT_V=1.0.123
 HOST_VER=$(lsb_release -sr | cut -d. -f1)
 
@@ -83,7 +83,7 @@ get_version() {
     pkg=$1
     sp="[[:space:]]"
     pkg_info=$(dpkg -l \
-        | sed -En "s|^ii.*($pkg)$sp*([0-9a-z\.-:]*)$sp.*|\1 \2|p")
+        | sed -En "s|^ii.*($pkg)$sp*([0-9a-z\.-:]*)$sp*amd64$sp*.*|\1 \2|p")
     echo $pkg_info | cut -d' ' -f2
 }
 
@@ -103,21 +103,26 @@ tkldev-setup $appname \
 # if v17.x (bullseye) being built on v16.x (buster) get/build right bootstrap
 TKL_VER=$(head -1 $BT_PRODUCTS/$appname/changelog | cut -d' ' -f1)
 MAJ_VER_NO=$(basename $(echo $TKL_VER | tr '-' '/') | cut -d'.' -f1)
-if [[ "$HOST_VER" -eq 10 ]] \
+if [[ "$HOST_VER" -eq 11 ]] \
     && [[ $MAJ_VER_NO -eq 17 ]]; then
-    warning "Buster host detected, attempting to build for Bullseye."
-    RC="rc1"
-    info "Assuming RC build. Nominating $RC."
-    export VERSION_TAG=$RC
-    export CODENAME="bullseye"
-    export RELEASE="debian/$CODENAME"
-    info "Fab v$(get_version fab) detected."
+    warning "Bullseye host detected, checking for bugfixed Bullseye fab package."
+    #RC="rc1"
+    #info "Assuming RC build. Nominating $RC."
+    #export VERSION_TAG=$RC
+    #export CODENAME="bullseye"
+    #export RELEASE="debian/$CODENAME"
+    info "Fab v$(get_version fab) detected - Fab v${REQ_FAB_V} required."
     if [[ "$(get_version fab)" != "$REQ_FAB_V"* ]]; then
         warning "Fab v$REQ_FAB_V required, attempting install."
-        fab_pkg=fab_${REQ_FAB_V}_stretch_amd64.deb
-        fab_url=https://github.com/turnkeylinux/fab/releases/download/v${REQ_FAB_V}
-        install_pkg $fab_pkg $fab_url
+        #fab_pkg=fab_${REQ_FAB_V}_stretch_amd64.deb
+        #fab_url=https://github.com/turnkeylinux/fab/releases/download/v${REQ_FAB_V}
+        #install_pkg $fab_pkg $fab_url
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y fab
     fi
+    # double check that we have the right fab version now
+    [[ "$(get_version fab)" == "$REQ_FAB_V"* ]] \
+        || fatal "Unable to install Fab v${REQ_FAB_V}"
     export GPGKEY="A8B2EF4287819B03D3516CCA76231C20425E9772"
     IMAGES="http://mirror.turnkeylinux.org/turnkeylinux/images"
     BOOTSTRAP_NAME="bootstrap-$CODENAME-$(dpkg --print-architecture)"
@@ -129,7 +134,7 @@ if [[ "$HOST_VER" -eq 10 ]] \
         exit_code=0
         #wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz || exit_code=$?
         #wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash || exit_code=$?
-        exit_code=1 # force rebuild of bootstrap...
+        #exit_code=1 # force rebuild of bootstrap...
         if [[ "$exit_code" -eq 0 ]]; then
             info "verifying $BOOTSTRAP_NAME"
             gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys $GPGKEY
@@ -163,7 +168,7 @@ if [[ "$HOST_VER" -eq 10 ]] \
                 $(dirname $BOOTSTRAP_PATH)/$BOOTSTRAP_NAME.tar.gz.hash
         fi
     fi
-    touch $BOOTSTRAP_PATH/bullseye_on_buster
+    #touch $BOOTSTRAP_PATH/bullseye_on_buster
 fi
 
 info "Preperation done. Building appliance $appname."


### PR DESCRIPTION
We fixed the original v17.0 initramfs bug (https://github.com/turnkeylinux/tracker/issues/1734) in fab (https://github.com/turnkeylinux/tracker/issues/1735) and I devised a plan that allowed us to push ahead.

My intention was to complete the v17.0 release / v17.1 re-release and then circle back to produce a bugfixed (v17.2) TKLDev. FYI TKLDev v17.1 does not include the bug, but does still include the fab version that causes the bug. TKLDev v17.2 was to include the new bugfixed fab package.

But then a whole heap of other stuff happened (such as the website crashing and being offline for over a week) and the v17.0/v17.1 release has really dragged out, so much so that we've had to produce a few bugfixed appliances. So the v17.1 builds should all be free of this bug, but newer releases (prior to today) are likely still (re)affected.

This is a hack to work around that (I should have done this sooner in retrospect). It will be irrelevant once we re-release TKLDev v17.2.

I generally prefer to remove redundant code, rather than just comment it out, but in this case, I'm going to just comment it, as we will need to think about transition soonish ([Bookworm is in early freeze](https://release.debian.org/bookworm/freeze_policy.html)). So some of that code, may be needed soonish...