### PR TITLE
Generate and publish screenshots when building ISOs with `bt-iso`

### DIFF
--- a/bin/clicksnap-setup
+++ b/bin/clicksnap-setup
@@ -10,18 +10,23 @@
 
 
 fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
-warning() { echo -e "WARNING [$(basename $0)]: $@"; }
+warn() { echo -e "WARNING [$(basename $0)]: $@"; }
 info() { echo "INFO [$(basename $0)]: $@"; }
 
 usage() {
     cat<<EOF
-Syntax: $(basename $0)
+Syntax: $(basename $0) [APP_NAME]
 Setup/update system ready for bt-iso (clicksnap & deps)
+
+Option::
+
+    APP_NAME        Optionally include APP_NAME so script can bail early if
+                    the app screenshot code doesn't exist
 
 Environment::
 
     BASE_DIR        base dir to clone clicksnap and tkldev-docker source into
-                    - if not set, will fallback to /turnkey
+                    - if not set, will fallback to /turnkey/public/
     BT_DEBUG        turn on debugging
 
 EOF
@@ -41,10 +46,15 @@ export BT_CONFIG=$BT/config
 mkdir -p $BASE_DIR
 GH_URL=https://github.com/turnkeylinux
 
+unset app
 while [ "$1" != "" ]; do
     case $1 in
         --help|-h )    usage;;
-        *)             usage "Unknown option '$1'";;
+        *)             if [[ -z "$app" ]]; then
+                            app="$1"
+                       else
+                           usage "Unknown option/multiple app names given: '$1'"
+                       fi;;
     esac
     shift
 done
@@ -55,8 +65,41 @@ install() {
     DEBIAN_FRONTEND=noninteractive apt-get -y install $@
 }
 
+git_pull() {
+    local dir=$1
+    local app=$2
+    cd $dir
+    local remote=$(sed -En "s|(^[a-zA-Z0-9_-]*)[[:space:]].*|\1|p" \
+                    <<<$(git remote -v | grep -m1 "turnkeylinux/$app"))
+    git pull $remote master
+}
+
+# dl & check for screenshot code first so we can bail as early as possible
+for dl in tkldev-docker clicksnap; do
+    if [[ -e "$BASE_DIR/$dl" ]]; then
+        if [[ -d "$BASE_DIR/$dl/.git" ]]; then
+            info "$dl already installed, checking for updates"
+            cd "$BASE_DIR/$dl"
+            git_pull "$BASE_DIR/$dl" "$dl"
+        else
+            fatal "$BASE_DIR/$dl exists but is not a git repo"
+        fi
+    else
+        info "Downloading $dl source"
+        git clone --depth=1 $GH_URL/$dl $BASE_DIR/$dl
+    fi
+done
+
+app=$(sed "s|-|_|g" <<<$app)
+if [[ -z "$app" ]]; then
+    warn "App name not given - continuing, but may fail later"
+elif ! ls $BASE_DIR/clicksnap/src/apps/ | grep -q -w "$app" \
+        && [[ -z "$no_screens" ]] ; then
+    fatal "Clicksnap code for $app not found (checked in $BASE_DIR/clicksnap/src/apps/)"
+fi
+
 # sed, fab & deck should be installed, but just in case
-deps="podman jq sed fab deck"
+deps="podman sed fab deck"
 missing=''
 for dep in $deps; do
     which $dep >/dev/null || missing="$missing $dep"
@@ -79,13 +122,8 @@ case "$(which cargo || echo 'fail')" in
         fatal "Unexpected cargo path: '$1'";;
 esac
 
-for app in tkldev-docker clicksnap; do
-    info "Downloading $app source"
-    git clone --depth=1 $GH_URL/$app $BASE_DIR/$app
-done
-
 cd $BASE_DIR/clicksnap
 info "Building & installing clicksnap"
 cargo build
-ln -s $PWD/target/debug/clicksnap /usr/local/bin/clicksnap
-ln -s $BASE_DIR/tkldev-docker/dockerize.sh /usr/local/bin/dockerize
+ln -sf $PWD/target/debug/clicksnap /usr/local/bin/clicksnap
+ln -sf $BASE_DIR/tkldev-docker/dockerize.sh /usr/local/bin/dockerize

--- a/bin/clicksnap-setup
+++ b/bin/clicksnap-setup
@@ -1,13 +1,12 @@
 #!/bin/bash -e
-# Copyright (c) 2023 TurnKey GNU/Linux - http://www.turnkeylinux.org
-# 
+# Copyright (c) 2023 TurnKey GNU/Linux - https://www.turnkeylinux.org
+#
 # This file is part of buildtasks.
-# 
+#
 # Buildtasks is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your
 # option) any later version.
-
 
 fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
 warn() { echo -e "WARNING [$(basename $0)]: $@"; }
@@ -30,8 +29,8 @@ Environment::
     BT_DEBUG        turn on debugging
 
 EOF
-    if [[ "$#" -ne 0 ]]; then
-        echo "Error: $@"
+    if [[ -n "$1" ]]; then
+        echo "Error: $@" >&2
         exit 1
     fi
     exit
@@ -61,6 +60,7 @@ done
 
 install() {
     info "Updating apt cache and installing deps:" $@
+    info "installing $@"
     apt-get -qq update
     DEBIAN_FRONTEND=noninteractive apt-get -y install $@
 }
@@ -108,7 +108,8 @@ done
 
 case "$(which cargo || echo 'fail')" in
     "$HOME/.cargo/bin/cargo")
-        true;;
+        info "Rust installed via rustup detected, attempting update"
+        rustup update;;
     /usr/bin/cargo)
         warn "system installed rust detected; continuing but may cause issues\n" \
              "   - if you encountner issues, please remove rust and rerun";;

--- a/bin/clicksnap-setup
+++ b/bin/clicksnap-setup
@@ -1,0 +1,91 @@
+#!/bin/bash -e
+# Copyright (c) 2023 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# This file is part of buildtasks.
+# 
+# Buildtasks is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo -e "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+    cat<<EOF
+Syntax: $(basename $0)
+Setup/update system ready for bt-iso (clicksnap & deps)
+
+Environment::
+
+    BASE_DIR        base dir to clone clicksnap and tkldev-docker source into
+                    - if not set, will fallback to /turnkey
+    BT_DEBUG        turn on debugging
+
+EOF
+    if [[ "$#" -ne 0 ]]; then
+        echo "Error: $@"
+        exit 1
+    fi
+    exit
+}
+
+[ -n "$BT_DEBUG" ] && set -x
+
+export BT=$(dirname $(dirname $(readlink -f $0)))
+export BT_CONFIG=$BT/config
+
+[[ -n "$BASE_DIR" ]] || BASE_DIR=/turnkey/public
+mkdir -p $BASE_DIR
+GH_URL=https://github.com/turnkeylinux
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --help|-h )    usage;;
+        *)             usage "Unknown option '$1'";;
+    esac
+    shift
+done
+
+install() {
+    info "Updating apt cache and installing deps:" $@
+    apt-get -qq update
+    DEBIAN_FRONTEND=noninteractive apt-get -y install $@
+}
+
+# sed, fab & deck should be installed, but just in case
+deps="podman jq sed fab deck"
+missing=''
+for dep in $deps; do
+    which $dep >/dev/null || missing="$missing $dep"
+done
+[[ -z "$missing" ]] || install $missing
+
+case "$(which cargo || echo 'fail')" in
+    "$HOME/.cargo/bin/cargo")
+        true;;
+    /usr/bin/cargo)
+        warn "system installed rust detected; continuing but may cause issues\n" \
+             "   - if you encountner issues, please remove rust and rerun";;
+    fail)
+        info "Installing rust via rustup"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        echo "export PATH=\"\$HOME/.cargo/bin:\$PATH\"" > $HOME/.bashrc.d/rust
+        chmod +x $HOME/.bashrc.d/rust
+        source $HOME/.bashrc.d/rust;;
+    *)
+        fatal "Unexpected cargo path: '$1'";;
+esac
+
+for app in tkldev-docker clicksnap; do
+    info "Downloading $app source"
+    git clone --depth=1 $GH_URL/$app $BASE_DIR/$app
+done
+
+cd $BASE_DIR/clicksnap
+info "Building & installing clicksnap"
+cargo build
+ln -s $PWD/target/debug/clicksnap /usr/local/bin/clicksnap
+ln -s $BASE_DIR/tkldev-docker/dockerize.sh /usr/local/bin/dockerize

--- a/bin/generate-buildenv
+++ b/bin/generate-buildenv
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2016-2022 TurnKey GNU/Linux - https://www.turnkeylinux.org
+# Copyright (c) 2016-2023 TurnKey GNU/Linux - https://www.turnkeylinux.org
 # 
 # This file is part of buildtasks.
 # 
@@ -13,7 +13,7 @@ warning() { echo "WARNING [$(basename $0)]: $@"; }
 info() { echo "INFO [$(basename $0)]: $@"; }
 
 usage() {
-cat<<EOF
+    cat<<EOF
 Syntax: $(basename $0) target target-args
 Print build environment related to target build type
 
@@ -30,16 +30,17 @@ Targets::
     openstack   path/to/iso.hash
 
 EOF
-exit 1
+    exit 1
 }
 
 BT=$(dirname $(dirname $(readlink -f $0)))
 BT_CONFIG=$BT/config
 . $BT/config/common.cfg
 
-[ -z "$RELEASE" ] || CODENAME=$(basename $RELEASE)
-[ -n "$CODENAME" ] || CODENAME=$(lsb_release -s -c)
-[ -n "$ARCH" ] || ARCH=$(dpkg --print-architecture)
+[[ -z "$RELEASE" ]] || CODENAME=$(basename $RELEASE)
+[[ -n "$CODENAME" ]] || CODENAME=$(lsb_release -s -c)
+[[ -n "$ARCH" ]] || ARCH=$(dpkg --print-architecture)
+[[ -n "$TKL_PUB" ]] || TKL_PUB=/turnkey/public
 
 _git_state() {
     dir=$1
@@ -86,6 +87,8 @@ bt_iso() {
     _git_state $FAB_PATH/cdroots
     _git_state $BT_PRODUCTS/core
     _git_state $BT_PRODUCTS/$appname
+    _git_state $TKL_PUB/clicksnap
+    _git_state $TKL_PUB/tkldev-docker
     _git_state $BT_PROFILES
 
     bootstrap_hash=$FAB_PATH/bootstraps/bootstrap-$CODENAME-$ARCH.tar.gz.hash
@@ -94,6 +97,7 @@ bt_iso() {
 
     echo "fab $(fab --version)"
     echo "deck $(deck --version)"
+    echo "podman $(podman --version)"
 }
 
 bt_img() {
@@ -113,7 +117,13 @@ bt_img() {
 }
 
 bt_ec2() {
-    echo "boto $(python -c 'import boto; print boto.__version__')"
+    if which python >/dev/null; then
+        echo "boto (py2) $(python -c 'import boto; print boto.__version__')"
+    else
+        echo "/usr/bin/python not found - trying python2"
+        echo "boto (py2) $(python2 -c 'import boto; print boto.__version__')"
+    fi
+    echo "boto (py3) $(python3 -c 'import boto; print boto.__version__')"
 }
 
 bt_vm() {

--- a/bin/iso-publish
+++ b/bin/iso-publish
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# Copyright (c) 2011-2023 TurnKey GNU/Linux - http://www.turnkeylinux.org
 # 
 # This file is part of buildtasks.
 # 
@@ -13,10 +13,12 @@ info() { echo "INFO [$(basename $0)]: $@"; }
 fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
 warning() { echo "WARNING [$(basename $0)]: $@"; }
 
+[[ -z "$BT_DEBUG" ]] || set -x
+
 FILES=$*
 
 usage() {
-cat<<EOF
+    cat<<EOF
 Syntax: $(basename $0) iso...isoN
 Publish release ISO and related metafiles
 
@@ -24,26 +26,30 @@ Environment::
 
     BT_PUBLISH_IMGS
     BT_PUBLISH_META
+    BT_PUBLISH_SCREENS
     BT_PUBLISH_PROFILES
 
+    BT_DEBUG
+
 EOF
-exit 1
+    exit 1
 }
 
-if [[ "${#FILES}" < "1" ]]; then
-    usage
+if [[ ${#FILES} -lt 1 ]]; then
+    usage "Must provide at least one ISO name"
 fi
 
 export BT=$(dirname $(dirname $(readlink -f $0)))
 export BT_CONFIG=$BT/config
 . $BT/config/common.cfg
 
-[ -n "$BT_PUBLISH_IMGS" ] || fatal "BT_PUBLISH_IMGS not set"
-[ -n "$BT_PUBLISH_META" ] || fatal "BT_PUBLISH_META not set"
-[ -n "$BT_PUBLISH_PROFILES" ] || fatal "BT_PUBLISH_PROFILES not set"
+[[ -n "$BT_PUBLISH_IMGS" ]] || fatal "BT_PUBLISH_IMGS not set"
+[[ -n "$BT_PUBLISH_META" ]] || fatal "BT_PUBLISH_META not set"
+[[ -n "$BT_PUBLISH_SCREENS" ]] || fatal "BT_PUBLISH_SCREENS not set"
+[[ -n "$BT_PUBLISH_PROFILES" ]] || fatal "BT_PUBLISH_PROFILES not set"
 
 for f in $FILES; do
-    [ -e $f ] || fatal "$f does not exist"
+    [[ -e $f ]] || fatal "$f does not exist"
 
     O=$(dirname $f)
     name=$(basename $f | sed 's/.iso//')
@@ -56,9 +62,12 @@ for f in $FILES; do
     export PUBLISH_DEST=${BT_PUBLISH_META}/
     $BT/bin/publish-files $O/$name.{changelog,manifest,iso.buildenv,iso.hash}
 
-    if [ -e $O/$name.tklbam/*.tar.gz ]; then
+    if find $O/$name.screens -type f -name "*.png" -print -quit; then
+        export PUBLISH_DEST=${BT_PUBLISH_SCREENS}
+        $BT/bin/publish-files $O/$name.screens/*.png
+    fi
+    if find $O/$name.tklbam -type f -name "*.tar.gz" -print -quit; then
         export PUBLISH_DEST=${BT_PUBLISH_PROFILES}/
         $BT/bin/publish-files $O/$name.tklbam/*.tar.gz
     fi
 done
-

--- a/bin/iso-release
+++ b/bin/iso-release
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# Copyright (c) 2011-2023 TurnKey GNU/Linux - https://www.turnkeylinux.org
 # 
 # This file is part of buildtasks.
 # 
@@ -14,33 +14,43 @@ fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
 warning() { echo "WARNING [$(basename $0)]: $@"; }
 
 usage() {
-cat<<EOF
+    cat<<EOF
 Syntax: $(basename $0) outdir
 Generate release files for publishing
 
 Options::
 
+    --no-screens        do not error if screenshots missing
     --force             delete release files in outdir if they exist
+    --help              show this help and exit
 
+Env::
+
+    BT_DEBUG
 EOF
-exit 1
+    exit 1
 }
 
-while [ "$1" != "" ]; do
+unset force no_screens
+while [[ "$1" != "" ]]; do
     case $1 in
-        --help|-h )  usage;;
-        --force)     force="yes";;
-        *)           if [ -n "$O" ]; then usage; else O=$1; fi ;;
+        --help|-h)      usage;;
+        --no-screens)   no_screens="true";;
+        --force)        force="yes";;
+        *)              if [ -n "$O" ]; then usage; else O=$1; fi;;
     esac
     shift
 done
 
-[ -n "$O" ] || usage
-[ -e "$O" ] || fatal "$O does not exist"
+[[ -z "$BT_DEBUG" ]] || set -x
 
-[ -e changelog ] || fatal "changelog not found"
-[ -e build/product.iso ] || fatal "build/product.iso not found"
-[ -e build/root.sandbox ] || fatal "build/root.sandbox not found"
+[[ -n "$O" ]] || usage
+[[ -e "$O" ]] || fatal "$O does not exist"
+
+[[ -e changelog ]] || fatal "changelog not found"
+[[ -e build/product.iso ]] || fatal "build/product.iso not found"
+[[ -e build/root.sandbox ]] || fatal "build/root.sandbox not found"
+[[ -n "$no_screens" ]] || [[ -e build/screens ]] || fatal "build/screens not found"
 
 export BT=$(dirname $(dirname $(readlink -f $0)))
 export BT_CONFIG=$BT/config
@@ -49,9 +59,9 @@ export BT_CONFIG=$BT/config
 rootfs=build/root.sandbox
 name=$(cat $rootfs/etc/turnkey_version)
 appname=$(echo $name |sed 's/turnkey-\(.*\)-[0-9].*/\1/')
-[ -n "$name" ] || fatal "could not identify name"
+[[ -n "$name" ]] || fatal "could not identify name"
 
-if [ "$force" == "yes" ]; then
+if [[ "$force" == "yes" ]]; then
     rm -f $O/$name.iso
     rm -f $O/$name.iso.hash
     rm -f $O/$name.iso.buildenv
@@ -59,24 +69,35 @@ if [ "$force" == "yes" ]; then
     rm -f $O/$name.changelog
     rm -f $O/$name.log
     rm -rf $O/$name.tklbam
+    rm -rf $O/$name.screens
 fi
 
-[ -e $O/$name.iso ] && fatal "$O/$name.iso already exists"
-[ -e $O/$name.iso.hash ] && fatal "$O/$name.iso.hash already exists"
-[ -e $O/$name.iso.buildenv ] && fatal "$O/$name.iso.buildenv already exists"
-[ -e $O/$name.manifest ] && fatal "$O/$name.manifest already exists"
-[ -e $O/$name.changelog ] && fatal "$O/$name.changelog already exists"
-[ -e $O/$name.tklbam ] && fatal "$O/$name.tklbam already exists"
+[[ ! -e $O/$name.iso ]] || fatal "$O/$name.iso already exists"
+[[ ! -e $O/$name.iso.hash ]] || fatal "$O/$name.iso.hash already exists"
+[[ ! -e $O/$name.iso.buildenv ]] || fatal "$O/$name.iso.buildenv already exists"
+[[ ! -e $O/$name.manifest ]] || fatal "$O/$name.manifest already exists"
+[[ ! -e $O/$name.changelog ]] || fatal "$O/$name.changelog already exists"
+[[ ! -e $O/$name.tklbam ]] || fatal "$O/$name.tklbam already exists"
+[[ ! -e $O/$name.screens ]] || fatal "$O/$name.screens already exists"
 
-[ -e build/log ] && cp build/log $O/$name.log
+[[ -e build/log ]] && cp build/log $O/$name.log
 cp changelog $O/$name.changelog
 cp build/product.iso $O/$name.iso
 $BT/bin/generate-signature $O/$name.iso
 $BT/bin/generate-manifest $rootfs > $O/$name.manifest
 $BT/bin/generate-buildenv iso $appname > $O/$name.iso.buildenv
-if [ -e $BT_PROFILES/$appname ]; then
+if [[ -e $BT_PROFILES/$appname ]]; then
     mkdir -p $O/$name.tklbam
     export PROFILES_CONF=$BT_PROFILES
     $BT/bin/generate-tklbam-profile $O/$name.iso $O/$name.tklbam
 fi
-
+if [[ -z "$no_screens" ]]; then
+    mkdir -p $O/$name.screens
+    prefix=$(echo "$name" | \
+        sed -En "s|turnkey-([a-z0-9-]+-[0-9]+\.[0-9]+[brc0-9]*)-.*|\1|p")
+    for screen in build/screens/screenshot-*.png; do
+        new_name=$(echo $(basename $screen) \
+                    | sed -En "s|screenshot-(.*\.png)|\1|p")
+        cp $screen $O/$name.screens/$prefix-$new_name
+    done
+fi

--- a/bin/publish-files
+++ b/bin/publish-files
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # depends: awscli
-# Copyright (c) 2011-2015 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# Copyright (c) 2011-2023 TurnKey GNU/Linux - http://www.turnkeylinux.org
 # 
 # This file is part of buildtasks.
 # 
@@ -14,7 +14,7 @@ fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
 info() { echo "INFO [$(basename $0)]: $@"; }
 
 usage() {
-cat<<EOF
+    cat<<EOF
 Syntax: $0 file...fileN
 Publish files (ignoring file paths) to PUBLISH_DEST
 
@@ -27,15 +27,15 @@ Environment::
     BT_CONFIG       - buildtasks config directory
     PUBLISH_DEST    - destination s3://bucket[/prefix]
 EOF
-exit 1
+    exit 1
 }
 
-if [[ "$#" < "1" ]]; then
+if [[ $# -lt 1 ]]; then
     usage
 fi
 
-[ -n "$BT_CONFIG" ] || fatal "BT_CONFIG not set"
-[ -n "$PUBLISH_DEST" ] || fatal "PUBLISH_DEST not set"
+[[ -n "$BT_CONFIG" ]] || fatal "BT_CONFIG not set"
+[[ -n "$PUBLISH_DEST" ]] || fatal "PUBLISH_DEST not set"
 
 . $BT_CONFIG/aws.cfg
 
@@ -53,4 +53,3 @@ done
 
 cd -
 rm -rf $tmpdir
-

--- a/bt-docker
+++ b/bt-docker
@@ -84,7 +84,7 @@ mkdir -p $O
 
 # hack for cloudtasks issues with pre command
 if [ ! -e /root/docker-setup.done ]; then
-    /turnkey/buildtasks/bin/docker-setup
+    $BT/bin/docker-setup
     touch /root/docker-setup.done
 fi
 

--- a/bt-iso
+++ b/bt-iso
@@ -155,6 +155,19 @@ if [[ -z "$skip_setup" ]]; then
             info "Setting up clicksnap and dockerize"
             $BT/bin/clicksnap-setup $appname
             touch /root/clicksnap-setup.done
+        else
+            setup_time=$(date -r /root/clicksnap-setup.done +%s)
+            allowed_age=$(( $setup_time + 86400 )) # 24 hours
+            if [[ $allowed_age -lt $(date +%s) ]]; then
+                info "Attempting clicksnap update"
+                clone_or_pull /turnkey/public/clicksnap turnkeylinux/clicksnap
+                touch /root/clicksnap-setup.done
+            fi
+            app=$(sed "s|-|_|g" <<<$appname)
+            if ! ls $BASE_DIR/clicksnap/src/apps/ | grep -q -w "$app"; then
+                fatal "Clicksnap code for $app not found (checked in /turnkey"\
+                      "/public/clicksnap/src/apps/)"
+            fi
         fi
     fi
 

--- a/bt-iso
+++ b/bt-iso
@@ -125,6 +125,17 @@ done
 [[ -n "$appname" ]] || usage "Must give one app name"
 [[ -n "$BT_DEBUG" ]] && set -x
 
+# adjust which clicksnap module to use where need be
+if [[ -z "$no_screens" ]]; then
+    case $appname in
+        tkldev)
+            info "TKLDev build - disabling screenshots as no web UI"
+            no_screens="true";;
+        *)
+            clicksnap_mod=$(sed "s|-|_|g" <<<$appname);;
+    esac
+fi
+
 export BT=$(dirname $(readlink -f $0))
 export BT_CONFIG=$BT/config
 . $BT_CONFIG/common.cfg
@@ -142,6 +153,7 @@ else
 fi
 
 cd $BT
+BASE_DIR=/turnkey/public
 COMMIT_ID=$(git rev-parse --short HEAD)
 if [[ -z "$skip_setup" ]]; then
     # Leverage tkldev-setup to ensure important repos are cloned and at latest
@@ -160,13 +172,13 @@ if [[ -z "$skip_setup" ]]; then
             allowed_age=$(( $setup_time + 86400 )) # 24 hours
             if [[ $allowed_age -lt $(date +%s) ]]; then
                 info "Attempting clicksnap update"
-                clone_or_pull /turnkey/public/clicksnap turnkeylinux/clicksnap
+                clone_or_pull $BASE_DIR/clicksnap turnkeylinux/clicksnap
                 touch /root/clicksnap-setup.done
             fi
-            app=$(sed "s|-|_|g" <<<$appname)
-            if ! ls $BASE_DIR/clicksnap/src/apps/ | grep -q -w "$app"; then
-                fatal "Clicksnap code for $app not found (checked in /turnkey"\
-                      "/public/clicksnap/src/apps/)"
+            if ! ls $BASE_DIR/clicksnap/src/apps/ \
+                    | grep -q -w "$clicksnap_mod"; then
+                fatal "Clicksnap code for $clicksnap_mod not found" \
+                      " (checked in /turnkey/public/clicksnap/src/apps/)"
             fi
         fi
     fi

--- a/bt-iso
+++ b/bt-iso
@@ -24,6 +24,7 @@ Arguments::
 
 Options::
 
+    -n|--no-screens     - skip taking screenshots
     --publish           - publish iso, release files and tklbam profile
 
 Environment::
@@ -34,27 +35,32 @@ exit 1
 }
 
 ARGS="$@"
-
-while [ "$1" != "" ]; do
+unset no-screens
+while [[ "$1" != "" ]]; do
     case $1 in
-        --help|-h )    usage;;
-        --publish)     publish="yes";;
-        *)             if [ -n "$appname" ]; then usage; else appname=$1; fi ;;
+        --help|-h)          usage;;
+        --publish)          publish="yes";;
+        -n|--no-screens)    no_screens='';;
+        *)                  if [ -n "$appname" ]; then
+                                usage
+                            else
+                                appname=$1
+                            fi;;
     esac
     shift
 done
 
-[ -n "$appname" ] || usage
-[ -n "$BT_DEBUG" ] && set -x
+[[ -n "$appname" ]] || usage
+[[ -n "$BT_DEBUG" ]] && set -x
 
 export BT=$(dirname $(readlink -f $0))
 export BT_CONFIG=$BT/config
 . $BT_CONFIG/common.cfg
 
-if [ "$publish" == "yes" ]; then
-    [ -n "$BT_PUBLISH_IMGS" ] || fatal "BT_PUBLISH_IMGS not set"
-    [ -n "$BT_PUBLISH_META" ] || fatal "BT_PUBLISH_META not set"
-    [ -n "$BT_PUBLISH_PROFILES" ] || fatal "BT_PUBLISH_PROFILES not set"
+if [[ "$publish" == "yes" ]]; then
+    [[ -n "$BT_PUBLISH_IMGS" ]] || fatal "BT_PUBLISH_IMGS not set"
+    [[ -n "$BT_PUBLISH_META" ]] || fatal "BT_PUBLISH_META not set"
+    [[ -n "$BT_PUBLISH_PROFILES" ]] || fatal "BT_PUBLISH_PROFILES not set"
 else
     warning "--publish was not specified"
 fi
@@ -106,6 +112,8 @@ git_unshallow() {
     fi
     cd -
 }
+
+
 
 cd $BT
 COMMIT_ID=$(git rev-parse --short HEAD)
@@ -202,9 +210,21 @@ fi
 mkdir -p $BT_ISOS
 $BT/bin/iso-release --force $BT_ISOS
 
-if [ "$publish" == "yes" ]; then
+if [[ "$publish" == "yes" ]]; then
     name=$(cat build/root.sandbox/etc/turnkey_version)
     $BT/bin/iso-publish $BT_ISOS/$name.iso
+fi
+
+if [[ -z "$no_screens" ]]; then
+    if [[ ! -f /root/clicksnap-setup.done ]]; then
+        info "Setting up clicksnap and dockerize"
+        $BT/bin/clicksnap-setup
+        touch /root/clicksnap-setup.done
+    fi
+    info "Product rootfs being loaded as docker container"
+    cont_name=$(DOCKER=podman dockerize.sh --deck build/root.sandbox)
+    info "Starting product docker container"
+    podman ...
 fi
 
 if [ -z "$BT_DEBUG" ]; then

--- a/bt-iso
+++ b/bt-iso
@@ -70,12 +70,6 @@ get_version() {
     echo $pkg_info | cut -d' ' -f2
 }
 
-install() {
-    info "Updating apt database and installing dependencies"
-    apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get -y install $@
-}
-
 git_unshallow() {
     local dir=$1
     local branch=$2
@@ -106,8 +100,12 @@ get_codename() {
     esac
 }
 
+container_status() {
+    podman container inspect $1 --format "{{.State.Status}}"
+}
+
 ARGS="$@"
-unset no-screens use_existing appname skip_setup TKL_CODENAME
+unset no_screens use_existing appname skip_setup TKL_CODENAME
 while [[ "$1" != "" ]]; do
     case $1 in
         --help|-h)          usage;;
@@ -158,7 +156,6 @@ if [[ -z "$skip_setup" ]]; then
             $BT/bin/clicksnap-setup $appname
             touch /root/clicksnap-setup.done
         fi
-        which jq >/dev/null || install jq
     fi
 
     # if TKL version doesn't match host, check out the relevant branches and
@@ -232,7 +229,7 @@ else
     cd $BT_PRODUCTS/$appname
     deck -D build/root.sandbox || true
     make clean || true
-    make || true
+    make 2>&1 | tee build/log || true
 
     if [[ ! -e build/product.iso ]]; then
         if [[ -z "$BT_DEBUG" ]]; then
@@ -246,33 +243,64 @@ fi
 if [[ -z "$no_screens" ]]; then
     if [[ -n "$use_existing" ]]; then
         info "Product iso being loaded as docker container"
-        image_name=$(dockerize --iso build/product.iso --name $appname | tail -1)
+        image_name=$(dockerize --quiet --iso build/product.iso --name $appname)
     else
         info "Product rootfs being loaded as docker container"
-        image_name=$(dockerize --rootfs build/root.sandbox --deck | tail -1)
+        image_name=$(dockerize --quiet --rootfs build/root.sandbox --deck)
     fi
+    
     info "Creating new product docker container from image and starting"
-    cont_id=$(podman create $image_name)
-    podman run -dt --tmpfs /tmp --tmpfs /run --tmpfs /run/lock $cont_id >/dev/null
-    app_ip=$(podman inspect $cont_id | jq -r '.[].NetworkSettings.IPAddress')
-    screenshot_dir=$BT_PRODUCTS/$appname/screens
-    mkdir -p $screenshot_dir
-    export TKL_SCREENSHOT_PATH=$screenshot_dir
-    podman run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-chrome:4.7.2-20221219
-    clicksnap test $appname https://$app_ip/
+    app_cont_id=$(podman run -dt --tmpfs /tmp --tmpfs /run --tmpfs /run/lock $image_name)
+    app_ip=$(podman inspect $app_cont_id --format "{{.NetworkSettings.IPAddress}}")
+    
+    export TKL_SCREENSHOT_PATH=$BT_PRODUCTS/$appname/build/screens
+    mkdir -p $TKL_SCREENSHOT_PATH
+    SELENIUM_CONT=docker.io/selenium/standalone-chrome
+    SELENIUM_TAG=4.7.2-20221219
+
+    # check if selenium container already exists
+    existing_instance=$(podman ps -a --format "{{.ID}}:{{.Image}}" \
+                | grep "$SELENIUM_CONT:$SELENIUM_TAG" || [[ $? == 1 ]])
+    existing_id=$(sed -En "s|(^[a-f0-9]+):.*|\1|p" <<<"$existing_instance")
+    if [[ -n "$existing_id" ]]; then
+        info "starting existing selenium container - assuming configured ok"
+        podman container start $existing_id >/dev/null
+        sel_cont_id=$existing_id
+    else
+        info "starting new selenium webdriver container (may require download)"
+        sel_cont_id=$(podman run -d -p 4444:4444 -p 7900:7900 \
+                        --shm-size="2g" $SELENIUM_CONT:$SELENIUM_TAG)
+    fi
+
+    # wait until container status is 'running'
+    while [[ $(container_status $sel_cont_id) != "running" ]]; do
+        sleep 1
+    done
+    info "container running - waiting for connection"
+    for ping in {1..20}; do
+        if ! curl localhost:4444 >/dev/null 2>&1; then
+           sleep 1
+        fi
+    done
+
+    info "taking screenshots"
+    TKL_SCREENSHOT_PATH=$TKL_SCREENSHOT_PATH clicksnap test $appname https://$app_ip/
 fi
 
 mkdir -p $BT_ISOS
-args="--force"
-[[ -z "$no_screens" ]] || args="$args --no-screens"
-$BT/bin/iso-release $args $BT_ISOS
+unset arg
+[[ -z "$no_screens" ]] || arg="--no-screens"
+$BT/bin/iso-release --force $arg $BT_ISOS
 
 if [[ "$publish" == "yes" ]]; then
     name=$(cat build/root.sandbox/etc/turnkey_version)
-    $BT/bin/iso-publish $args $BT_ISOS/$name.iso
+    $BT/bin/iso-publish $arg $BT_ISOS/$name.iso
 fi
 
 if [[ -z "$BT_DEBUG" ]]; then
     deck -D build/root.sandbox
     make clean
+    info "stopping $appname container: $(podman stop $app_cont_id)"
+    info "removing $appname container: $(podman rm $app_cont_id)"
+    info "removing $appname image: $(podman rmi $image_name)"
 fi

--- a/bt-iso
+++ b/bt-iso
@@ -14,8 +14,8 @@ warning() { echo "WARNING [$(basename $0)]: $@"; }
 info() { echo "INFO [$(basename $0)]: $@"; }
 
 usage() {
-cat<<EOF
-Syntax: $(basename $0) [ --publish ] appname
+    cat<<EOF
+Syntax: $(basename $0) [--publish | -u] [-n] [-s] appname
 Builds appliance appname (e.g., core) ISO
 
 Arguments::
@@ -25,45 +25,24 @@ Arguments::
 Options::
 
     -n|--no-screens     - skip taking screenshots
-    --publish           - publish iso, release files and tklbam profile
+    -u|--use-existing   - use an existing iso, rather than rebuilding, will
+                          fail if iso does not exist
+    -s|--skip-setup     - skip the inital setup step
+    --publish           - publish iso, release files and tklbam profile,
+                          incompatible with -u|--use-existing and
+                          -s|--skip-setup
 
 Environment::
 
     BT_DEBUG            - turn on debugging
+
 EOF
-exit 1
+    if [[ "$#" -ne 0 ]]; then
+        echo "Error: $@"
+        exit 1
+    fi
+    exit
 }
-
-ARGS="$@"
-unset no-screens
-while [[ "$1" != "" ]]; do
-    case $1 in
-        --help|-h)          usage;;
-        --publish)          publish="yes";;
-        -n|--no-screens)    no_screens='';;
-        *)                  if [ -n "$appname" ]; then
-                                usage
-                            else
-                                appname=$1
-                            fi;;
-    esac
-    shift
-done
-
-[[ -n "$appname" ]] || usage
-[[ -n "$BT_DEBUG" ]] && set -x
-
-export BT=$(dirname $(readlink -f $0))
-export BT_CONFIG=$BT/config
-. $BT_CONFIG/common.cfg
-
-if [[ "$publish" == "yes" ]]; then
-    [[ -n "$BT_PUBLISH_IMGS" ]] || fatal "BT_PUBLISH_IMGS not set"
-    [[ -n "$BT_PUBLISH_META" ]] || fatal "BT_PUBLISH_META not set"
-    [[ -n "$BT_PUBLISH_PROFILES" ]] || fatal "BT_PUBLISH_PROFILES not set"
-else
-    warning "--publish was not specified"
-fi
 
 clone_or_pull() {
     # If $dir doesn't exist, clone $repo. If it does, update from origin master
@@ -91,12 +70,10 @@ get_version() {
     echo $pkg_info | cut -d' ' -f2
 }
 
-install_pkg() {
-    _pkg=$1
-    _url=$2
-    wget -O /tmp/$_pkg $_url/$_pkg
-    apt install /tmp/$_pkg
-    rm -rf /tmp/$_pkg
+install() {
+    info "Updating apt database and installing dependencies"
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get -y install $@
 }
 
 git_unshallow() {
@@ -113,121 +90,189 @@ git_unshallow() {
     cd -
 }
 
+get_codename() {
+    local tkl_ver=$1
+    case $tkl_ver in
+        16*)
+            TKL_CODENAME=buster;;
+        17*)
+            TKL_CODENAME=bullseye;;
+        18*)
+            TKL_CODENAME=bookworm;;
+        19*)
+            TKL_CODENAME=trixie;;
+        *)
+            fatal "Unrecognised TKL version: $tkl_ver";;
+    esac
+}
 
+ARGS="$@"
+unset no-screens use_existing appname skip_setup TKL_CODENAME
+while [[ "$1" != "" ]]; do
+    case $1 in
+        --help|-h)          usage;;
+        --publish)          publish="yes";;
+        -n|--no-screens)    no_screens="true";;
+        -s|--skip-setup)    skip_setup="true";;
+        -u|--use-existing)  use_existing="true";;
+        *)                  if [[ -n "$appname" ]]; then
+                                usage "Accepts only one appliance name"
+                            else
+                                appname=$1
+                            fi;;
+    esac
+    shift
+done
+
+[[ -n "$appname" ]] || usage "Must give one app name"
+[[ -n "$BT_DEBUG" ]] && set -x
+
+export BT=$(dirname $(readlink -f $0))
+export BT_CONFIG=$BT/config
+. $BT_CONFIG/common.cfg
+
+if [[ "$publish" == "yes" ]]; then
+    unset msg
+    [[ -n "$BT_PUBLISH_IMGS" ]] || fatal "BT_PUBLISH_IMGS not set"
+    [[ -n "$BT_PUBLISH_META" ]] || fatal "BT_PUBLISH_META not set"
+    [[ -n "$BT_PUBLISH_SCREENS" ]] || fatal "BT_PUBLISH_SCREENS not set"
+    [[ -n "$BT_PUBLISH_PROFILES" ]] || fatal "BT_PUBLISH_PROFILES not set"
+    [[ -z "$use_existing" ]] || usage "conflicting options: --publish / -u|--use-existing"
+    [[ -z "$skip_setup" ]] || usage "conflicting options: --publish / -s|--skip-setup"
+else
+    warning "--publish was not specified"
+fi
 
 cd $BT
 COMMIT_ID=$(git rev-parse --short HEAD)
-# Leverage tkldev-setup to ensure important repos are cloned and at latest
-# commit; also ensures RELEASE & ARCH are set.
-tkldev-setup $appname \
+if [[ -z "$skip_setup" ]]; then
+    # Leverage tkldev-setup to ensure important repos are cloned and at latest
+    # commit; also ensures RELEASE & ARCH are set.
+    tkldev-setup $appname \
         || warning "tkldev-setup failed. Attempting to continue anyway."
 
-# if TKL version doesn't match host, check out the relevant branches and
-# attempt to download the right bootstrap; otherwise build it
-TKL_HOST_VER=$(turnkey-version -t | cut -d. -f1)
-TKL_BUILD_VER=$(sed -nE "1s|turnkey-[a-z0-9-]*-([0-9]+).*|\1|p" \
-    $BT_PRODUCTS/$appname/changelog)
-if [[ "$TKL_HOST_VER" != "$TKL_BUILD_VER" ]]; then
-    warning "Host TKL version ($TKL_HOST_VER) does not match guest version" \
-       " ($TKL_BUILD_VER)"
-    case $TKL_BUILD_VER in
-        16)
-            TKL_CODENAME=buster;;
-        17)
-            TKL_CODENAME=bullseye;;
-        18)
-            TKL_CODENAME=bookworm;;
-        19)
-            TKL_CODENAME=trixie;;
-        *)
-            fatal "Unrecognised TKL version: $TKL_BUILD_VER";;
-    esac
-    export RELEASE=debian/$TKL_CODENAME
-    git_unshallow "/turnkey/buildtasks" "$TKL_BUILD_VER.x"
-    # if buildtasks has changed, restart bt-iso
-    cd $BT
-    if [[ "$(git rev-parse --short HEAD)" != "$COMMIT_ID" ]]; then
-        exec ./$(basename $0) $ARGS
+    # unless -n|--no-screens set up clicksnap and check for clicksnap file
+    if [[ -z "$no_screens" ]]; then
+        if [[ ! -f /root/clicksnap-setup.done ]]; then
+            info "Setting up clicksnap and dockerize"
+            $BT/bin/clicksnap-setup $appname
+            touch /root/clicksnap-setup.done
+        fi
+        which jq >/dev/null || install jq
     fi
-    cd -
-    git_unshallow "$FAB_PATH/common" "$TKL_BUILD_VER.x"
-    KEY=$FAB_PATH/common/keys/tkl-$TKL_CODENAME-images.asc
-    IMAGES="http://mirror.turnkeylinux.org/turnkeylinux/images"
-    BOOTSTRAP_NAME="bootstrap-$TKL_CODENAME-$(dpkg --print-architecture)"
-    BOOTSTRAP_PATH="$FAB_PATH/bootstraps/$TKL_CODENAME"
 
-    if [[ ! -d "$BOOTSTRAP_PATH" ]]; then
-        info "Attempting to download $BOOTSTRAP_NAME"
-        mkdir -p $(dirname $BOOTSTRAP_PATH)
-        cd $(dirname $BOOTSTRAP_PATH)
-        exit_code=0
-        wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz || exit_code=$?
-        wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash || exit_code=$?
-        if [[ "$exit_code" -eq 0 ]]; then
-            info "verifying $BOOTSTRAP_NAME"
-            TMP_KEYRING="$(mktemp -d)/tmp.gpg"
-            GPG="gpg --no-default-keyring --keyring $TMP_KEYRING"
-            $GPG --import $FAB_PATH/common/keys/tkl-$TKL_CODENAME-images.asc
-            $GPG --verify $BOOTSTRAP_NAME.tar.gz.hash
+    # if TKL version doesn't match host, check out the relevant branches and
+    # attempt to download the right bootstrap; otherwise build it
+    TKL_HOST_VER=$(turnkey-version -t | cut -d. -f1)
+    TKL_BUILD_VER=$(sed -nE "1s|turnkey-[a-z0-9-]*-([0-9]+).*|\1|p" \
+        $BT_PRODUCTS/$appname/changelog)
+    if [[ "$TKL_HOST_VER" != "$TKL_BUILD_VER" ]]; then
+        warning "Host TKL version ($TKL_HOST_VER) does not match guest version" \
+                " ($TKL_BUILD_VER)"
+        unset TKL_CODENAME
+        get_codename $TKL_BUILD_VER
+        export RELEASE=debian/$TKL_CODENAME
+        git_unshallow "/turnkey/buildtasks" "$TKL_BUILD_VER.x"
+        # if buildtasks has changed, restart bt-iso
+        cd $BT
+        if [[ "$(git rev-parse --short HEAD)" != "$COMMIT_ID" ]]; then
+            exec ./$(basename $0) $ARGS
+        fi
+        cd -
+        git_unshallow "$FAB_PATH/common" "$TKL_BUILD_VER.x"
+        KEY=$FAB_PATH/common/keys/tkl-$TKL_CODENAME-images.asc
+        IMAGES="http://mirror.turnkeylinux.org/turnkeylinux/images"
+        BOOTSTRAP_NAME="bootstrap-$TKL_CODENAME-$(dpkg --print-architecture)"
+        BOOTSTRAP_PATH="$FAB_PATH/bootstraps/$TKL_CODENAME"
 
-            info "unpacking $BOOTSTRAP_NAME"
-            mkdir $BOOTSTRAP_PATH
-            tar -zxf $BOOTSTRAP_NAME.tar.gz -C $BOOTSTRAP_PATH
-            cd -
-        else
-            warning "Downloading bootstrap failed."
-            info "Attempting to build bootstrap."
-            unset PUBLISH
-            BOOTSTRAP_SRC=$(dirname $FAB_PATH)/bootstrap
-            [[ "$publish" != "yes" ]] || PUBLISH="--publish"
-            $BT/bt-bootstrap $PUBLISH --no-clean --force \
-                || fatal "Building bootstrap failed... :("
-            rsync --delete -Hac $BOOTSTRAP_SRC/build/bootstrap/ \
-                $FAB_PATH/bootstraps/$TKL_CODENAME/
-            # create symlinks so bin/generate-buildenv completes successfully
-            ln -s $BT_BUILDS/bootstrap/$BOOTSTRAP_NAME.tar.gz \
-                $(dirname $BOOTSTRAP_PATH)/$BOOTSTRAP_NAME.tar.gz
-            ln -s $BT_BUILDS/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash \
-                $(dirname $BOOTSTRAP_PATH)/$BOOTSTRAP_NAME.tar.gz.hash
+        if [[ ! -d "$BOOTSTRAP_PATH" ]]; then
+            info "Attempting to download $BOOTSTRAP_NAME"
+            mkdir -p $(dirname $BOOTSTRAP_PATH)
+            cd $(dirname $BOOTSTRAP_PATH)
+            exit_code=0
+            wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz || exit_code=$?
+            wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash || exit_code=$?
+            if [[ "$exit_code" -eq 0 ]]; then
+                info "verifying $BOOTSTRAP_NAME"
+                TMP_KEYRING="$(mktemp -d)/tmp.gpg"
+                GPG="gpg --no-default-keyring --keyring $TMP_KEYRING"
+                $GPG --import $FAB_PATH/common/keys/tkl-$TKL_CODENAME-images.asc
+                $GPG --verify $BOOTSTRAP_NAME.tar.gz.hash
+
+                info "unpacking $BOOTSTRAP_NAME"
+                mkdir $BOOTSTRAP_PATH
+                tar -zxf $BOOTSTRAP_NAME.tar.gz -C $BOOTSTRAP_PATH
+                cd -
+            else
+                warning "Downloading bootstrap failed."
+                info "Attempting to build bootstrap."
+                unset PUBLISH
+                BOOTSTRAP_SRC=$(dirname $FAB_PATH)/bootstrap
+                [[ "$publish" != "yes" ]] || PUBLISH="--publish"
+                $BT/bt-bootstrap $PUBLISH --no-clean --force \
+                    || fatal "Building bootstrap failed... :("
+                rsync --delete -Hac $BOOTSTRAP_SRC/build/bootstrap/ \
+                    $FAB_PATH/bootstraps/$TKL_CODENAME/
+                # create symlinks so bin/generate-buildenv completes successfully
+                ln -s $BT_BUILDS/bootstrap/$BOOTSTRAP_NAME.tar.gz \
+                    $(dirname $BOOTSTRAP_PATH)/$BOOTSTRAP_NAME.tar.gz
+                ln -s $BT_BUILDS/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash \
+                    $(dirname $BOOTSTRAP_PATH)/$BOOTSTRAP_NAME.tar.gz.hash
+            fi
         fi
     fi
 fi
 
-info "Preperation done. Building appliance $appname."
 cd $BT_PRODUCTS/$appname
-deck -D build/root.sandbox || true
-make clean || true
-make || true
+if [[ -n "$use_existing" ]]; then
+    ISO=build/product.iso
+    [[ -f "$ISO" ]] || fatal "iso $PWD/$ISO not found"
+else
+    info "Preperation done. Building appliance $appname."
+    cd $BT_PRODUCTS/$appname
+    deck -D build/root.sandbox || true
+    make clean || true
+    make || true
 
-if [ ! -e build/product.iso ]; then
-    if [ -z "$BT_DEBUG" ]; then
-        deck -D build/root.sandbox >/dev/null 2>&1 || true
-        make clean >/dev/null 2>&1 || true
+    if [[ ! -e build/product.iso ]]; then
+        if [[ -z "$BT_DEBUG" ]]; then
+            deck -D build/root.sandbox >/dev/null 2>&1 || true
+            make clean >/dev/null 2>&1 || true
+        fi
+        fatal "Build failed..."
     fi
-    fatal "Build failed..."
-fi
-
-mkdir -p $BT_ISOS
-$BT/bin/iso-release --force $BT_ISOS
-
-if [[ "$publish" == "yes" ]]; then
-    name=$(cat build/root.sandbox/etc/turnkey_version)
-    $BT/bin/iso-publish $BT_ISOS/$name.iso
 fi
 
 if [[ -z "$no_screens" ]]; then
-    if [[ ! -f /root/clicksnap-setup.done ]]; then
-        info "Setting up clicksnap and dockerize"
-        $BT/bin/clicksnap-setup
-        touch /root/clicksnap-setup.done
+    if [[ -n "$use_existing" ]]; then
+        info "Product iso being loaded as docker container"
+        image_name=$(dockerize --iso build/product.iso --name $appname | tail -1)
+    else
+        info "Product rootfs being loaded as docker container"
+        image_name=$(dockerize --rootfs build/root.sandbox --deck | tail -1)
     fi
-    info "Product rootfs being loaded as docker container"
-    cont_name=$(DOCKER=podman dockerize.sh --deck build/root.sandbox)
-    info "Starting product docker container"
-    podman ...
+    info "Creating new product docker container from image and starting"
+    cont_id=$(podman create $image_name)
+    podman run -dt --tmpfs /tmp --tmpfs /run --tmpfs /run/lock $cont_id >/dev/null
+    app_ip=$(podman inspect $cont_id | jq -r '.[].NetworkSettings.IPAddress')
+    screenshot_dir=$BT_PRODUCTS/$appname/screens
+    mkdir -p $screenshot_dir
+    export TKL_SCREENSHOT_PATH=$screenshot_dir
+    podman run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-chrome:4.7.2-20221219
+    clicksnap test $appname https://$app_ip/
 fi
 
-if [ -z "$BT_DEBUG" ]; then
+mkdir -p $BT_ISOS
+args="--force"
+[[ -z "$no_screens" ]] || args="$args --no-screens"
+$BT/bin/iso-release $args $BT_ISOS
+
+if [[ "$publish" == "yes" ]]; then
+    name=$(cat build/root.sandbox/etc/turnkey_version)
+    $BT/bin/iso-publish $args $BT_ISOS/$name.iso
+fi
+
+if [[ -z "$BT_DEBUG" ]]; then
     deck -D build/root.sandbox
     make clean
 fi

--- a/config.example/common.cfg
+++ b/config.example/common.cfg
@@ -1,12 +1,15 @@
-export BT_PUBLISH_LOGS="s3://BUCKET/logs"
-export BT_PUBLISH_IMGS="s3://BUCKET/images"
-export BT_PUBLISH_META="s3://BUCKET/metadata"
-export BT_PUBLISH_PROFILES="s3://BUCKET/profiles"
+BUCKET="..."
+export BT_PUBLISH_LOGS="s3://${BUCKET}/logs"
+export BT_PUBLISH_IMGS="s3://${BUCKET}/images"
+export BT_PUBLISH_META="s3://${BUCKET}/metadata"
+export BT_PUBLISH_SCREENS="s3://${BUCKET}/screens"
+export BT_PUBLISH_PROFILES="s3://${BUCKET}/profiles"
 export BT_GPGKEY=26147592087C0EDE42143B637761DEBABBCFBA7C
 export BT_ISOS=/mnt/isos
 export BT_IMGS=/mnt/imgs
 export BT_QEMU=/mnt/qemu
 export BT_BUILDS=/mnt/builds
+export BT_SCREENS=/mnt/screens
 export BT_PROFILES=/turnkey/tklbam-profiles
 export BT_PRODUCTS=/turnkey/fab/products
 # Some appliances derive latest version to install via GitHub API. To avoid


### PR DESCRIPTION
Fairly major (and some fairly minor) updates to `buildtasks`.

Primarily it is to support generating appliance screenshots at ISO build time (leveraging [`clicksnap`](https://github.com/turnkeylinux/clicksnap) and [`tkldev-docker`](https://github.com/turnkeylinux/tkldev-docker)) but there are also some styling updates too.

In retrospect, the code could have been trimmed (e.g. most of the options won't be used in production) but I figured that it was useful while I was developing this so may well be useful for debugging/further development?! (And it means less work now! :sunglasses: )

Also requires:
- https://github.com/turnkeylinux/clicksnap/pull/3
- https://github.com/turnkeylinux/tkldev-docker/pull/2