### PR TITLE
bt-iso improvements related to checking for clicksnap app screeny code

### DIFF
--- a/bt-iso
+++ b/bt-iso
@@ -219,9 +219,9 @@ if [[ -z "$skip_setup" ]]; then
                 cd -
                 touch /root/clicksnap-setup.done
             fi
-            if ! grep $appname <<<$(clicksnap list); then
-                fatal "Clicksnap code for $appname not found"
-            fi
+        fi
+        if ! grep $appname <<<$(clicksnap list); then
+            fatal "Clicksnap code for $appname not found"
         fi
     fi
 

--- a/bt-iso
+++ b/bt-iso
@@ -220,7 +220,7 @@ if [[ -z "$skip_setup" ]]; then
                 touch /root/clicksnap-setup.done
             fi
         fi
-        if ! grep $appname <<<$(clicksnap list); then
+        if ! grep -q $appname <<<$(clicksnap list); then
             fatal "Clicksnap code for $appname not found"
         fi
     fi

--- a/bt-iso
+++ b/bt-iso
@@ -202,11 +202,6 @@ cd "$BT"
 BASE_DIR=/turnkey/public
 COMMIT_ID=$(git rev-parse --short HEAD)
 if [[ -z "$skip_setup" ]]; then
-    # Leverage tkldev-setup to ensure important repos are cloned and at latest
-    # commit; also ensures RELEASE & ARCH are set.
-    tkldev-setup "$appname" \
-        || warning "tkldev-setup failed. Attempting to continue anyway."
-
     # unless -n|--no-screens set up clicksnap and check for clicksnap file
     if [[ -z "$no_screens" ]]; then
         if [[ ! -f /root/clicksnap-setup.done ]]; then
@@ -229,6 +224,11 @@ if [[ -z "$skip_setup" ]]; then
             fi
         fi
     fi
+
+    # Leverage tkldev-setup to ensure important repos are cloned and at latest
+    # commit; also ensures RELEASE & ARCH are set.
+    tkldev-setup "$appname" \
+        || warning "tkldev-setup failed. Attempting to continue anyway."
 
     # if TKL version doesn't match host, check out the relevant branches and
     # attempt to download the right bootstrap; otherwise build it

--- a/bt-iso
+++ b/bt-iso
@@ -150,7 +150,7 @@ done
 
 [[ -n "$appname" ]] || usage "Must give one app name"
 
-# adjust which clicksnap module to use where need be
+# don't try screens for tkldev & extend MAX_COUNT for gitlab
 if [[ -z "$no_screens" ]]; then
     case $appname in
         tkldev)
@@ -159,10 +159,7 @@ if [[ -z "$no_screens" ]]; then
         gitlab)
             # GitLab takes ages to start...
             export MAX_COUNT=70 # possibly overkill
-            clicksnap_mod=gitlab
             ;;
-        *)
-            clicksnap_mod="${appname//-/_}";;
     esac
 fi
 
@@ -227,9 +224,8 @@ if [[ -z "$skip_setup" ]]; then
                 cd -
                 touch /root/clicksnap-setup.done
             fi
-            if [[ ! -d "$BASE_DIR/clicksnap/src/apps/$clicksnap_mod" ]]; then
-                fatal "Clicksnap code for $clicksnap_mod not found" \
-                          " (checked in $BASE_DIR/clicksnap/src/apps/)"
+            if ! grep $appname <<<$(clicksnap list); then
+                fatal "Clicksnap code for $appname not found"
             fi
         fi
     fi


### PR DESCRIPTION
- Use new `clicksnap` functionality to check for appliance screenshot code
- Run `tkldev-setup` later so `bt-iso` errors earlier if no appliance screenshot code
- Fix bug so appliance screenshot code is always checked (unless `--no-screens`)