### PR TITLE
No screenshot of core either

### DIFF
--- a/bt-iso
+++ b/bt-iso
@@ -153,8 +153,8 @@ done
 # don't try screens for tkldev & extend MAX_COUNT for gitlab & canvas
 if [[ -z "$no_screens" ]]; then
     case $appname in
-        tkldev)
-            info "TKLDev build - disabling screenshots as no web UI"
+        tkldev|core)
+            info "$appname build - disabling screenshots as no web UI"
             no_screens="true";;
         gitlab|canvas)
             # GitLab & Canvas take ages to start...


### PR DESCRIPTION
Core screenshot will fail too. Probably should deal with this in `clicksnap`, but for now, just deal with it in `bt-iso`.