### PR TITLE
Update ec2 init-fence default page

### DIFF
--- a/patches/ec2/overlay/var/lib/inithooks/turnkey-init-fence/htdocs/index.html
+++ b/patches/ec2/overlay/var/lib/inithooks/turnkey-init-fence/htdocs/index.html
@@ -9,48 +9,79 @@
 <div id="please-initialize">
   <h1>Please initialize this system...</h1>
 
-  <p>Welcome to TurnKey! Before we fully expose this instance to a hostile Internet,
-  we need to initialize it. This will setup passwords, install security
-  updates, etc.</p>
+  <p>Welcome to your TurnKey <strong>@APP_NAME@</strong> appliance!</p>
 
-  <p>To continue you'll need to SSH into the <b>admin</b>
-  account, which will automatically start the <i>turnkey-init</i>
-  initialization program:</p>
+  <p>Before your server is fully exposed to a hostile Internet, this system needs to
+    be initialized. This will setup passwords, install security updates, etc.</p>
 
-    <img src="/turnkey-init-admin.png" />
+  <p>To initialize the system, you need to log into the "<b>admin</b>" account via SSH.</p>
 
-   <p>After initialization try reloading this page. This message will
-   disappear and you'll be able to access all services on this system
-   normally.</p>
+  <p>The <i>turnkey-init</i> initialization program should start automatically:</p>
+
+  <img src="/turnkey-init-admin.png" />
+
+  <p>After initialization reload this page. Instead of this message, you'll be able
+    to access your server as expected.</p>
 
 </div>
 
 <div id="howto-ssh">
 
-  <h2>How do I SSH into the admin account?</h2>
+  <h2>How do I log in via SSH?</h2>
 
-  <b>Using your SSH key-pair</b>: If you've
-    correctly configured an <a href="http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html">AWS SSH key-pair</a>, you'll be able to log into the <b>admin</b> account 
-    without having to enter a password using your SSH client (e.g., Putty on Windows).
+  <p>The recommended SSH client is OpenSSH - although there are other options. On Windows, you may need to
+    <a href="https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?pivots=windows-11">
+    set up OpenSSH first</a>. On Linux and MacOS it should already be available.</p>
+
+  <p>If you've correctly configured an <a
+        href="https://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/AccessingInstances.html">
+    AWS SSH key-pair</a>, you'll then be able to log into the <b>admin</b> account without having to
+    enter a password.</p>
+
+  <h4>Log in via SSH</h4>
+
+  <p>Then open a terminal and type the command:</p>
+
+  <pre id="p1">ssh admin@example.com</pre>
+
+  <p>If you are not using the default configured SSH keypair, you may need to provide the path
+    to your private key as well. Do that with the <i>-i</i> switch - like this:</p>
+
+  <pre id="p2">ssh -i path/to/private/key admin@example.com</pre>
+
+  <h4>Complete initialization</h4>
+
+  <p>Then complete the initialization steps as prompted.</p>
+
+  <p>Once your server has been initialized, reloading this page - or browsing to
+    <strong id="p3">https://example.com</strong> - will take you to your server's main
+    page.</p>
 
 </div>
 
 <div id="more-information">
 
-  <h2>Register for bundled support and 1-click cloud backup</h2>
+  <h2>Register for bundled support and cloud backup</h2>
   
-  <p>Each TurnKey solution on the AWS marketplace is bundled with e-mail
-  support and 1-click cloud backup and migration for no extra-charge.</p>
+  <p>Each TurnKey solution on the AWS marketplace is bundled with free "getting
+    started" e-mail support and 1 free level 1 support ticket per month. TurnKey
+    also provides a Cloud backup and migration service.</p>
 
-  <p>To benefit, sign up for a free <a href="https://hub.turnkeylinux.org/signup">TurnKey Hub</a> account if you don't already have one. We identify your AWS marketplace
-  subscription and eligibility for bundled services by your Amazon account id.</p>
+  <p>To benefit, sign up for a <a href="https://hub.turnkeylinux.org/signup">TurnKey Hub</a>
+    account if you don't already have one. Please see <a href="https://www.turnkeylinux.org/docs/awsmp">
+    AWS marketplace usage notes</a> for more information.</p>
+
+  <p>When contacting support, please note that you are using TurnKey via the AWS Marketplace
+    and provide your AWS account ID number.</p>
   
-  <h2>For more information, visit our website!</h2>
+  <h2>More information</h2>
 
-  <p>For further information, please consult the
-  <a href="https://www.turnkeylinux.org/$CODENAME">product page</a> and 
-  <a href="https://www.turnkeylinux.org/docs/awsmp">AWS marketplace usage notes</a> 
-  on the <a href="https://www.turnkeylinux.org">TurnKey GNU/Linux</a> website.</p>
+  <p>For further information regarding TurnKey @APP_NAME@, please consult the
+    <a href="https://www.turnkeylinux.org/@APP_NAME@">appliance product page</a> on
+    the <a href="https://www.turnkeylinux.org">TurnKey GNU/Linux</a> website.</p>
+
+  <p>For support, questions and/or feedback, please <a
+    href="https://www.turnkeylinux.org/contact">contact us</a>.</p>
 
 </div>
 
@@ -59,9 +90,7 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <script>
-$(function() {
-    $('a').each(function() { 
-        this.href = this.href.replace('__document.domain__', document.domain)
-    });
-});
+    document.getElementById("p1").innerHTML = "ssh admin@" + document.domain;
+    document.getElementById("p2").innerHTML = "ssh -i path/to/private/key admin@" + document.domain;
+    document.getElementById("p3").innerHTML = "https://" + document.domain;
 </script>


### PR DESCRIPTION
Update ec2 init-fence default page to keep it (mostly) inline with updates in inithooks: https://github.com/turnkeylinux/inithooks/pull/76