### PR TITLE
Add new AUTO_RUN inithooks key - used by init-fence firstboot scripts

### DIFF
--- a/patches/headless/overlay/usr/lib/inithooks/firstboot.d/29preseed
+++ b/patches/headless/overlay/usr/lib/inithooks/firstboot.d/29preseed
@@ -34,6 +34,7 @@ export APP_DOMAIN=DEFAULT
 export HUB_APIKEY=SKIP
 export SEC_ALERTS=SKIP
 export SEC_UPDATES=SKIP
+export AUTO_RUN=TRUE
 EOF
 
 chmod +x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*

--- a/patches/qemu/overlay/usr/lib/inithooks/firstboot.d/29preseed
+++ b/patches/qemu/overlay/usr/lib/inithooks/firstboot.d/29preseed
@@ -16,6 +16,7 @@ export APP_DOMAIN=DEFAULT
 export HUB_APIKEY=SKIP
 export SEC_ALERTS=SKIP
 export SEC_UPDATES=SKIP
+export AUTO_RUN=TRUE
 EOF
 
 chmod +x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*


### PR DESCRIPTION
Add new `AUTO_RUN` env var - set when auto self preseeded on headless builds.

Required by https://github.com/turnkeylinux/inithooks/pull/77