### PR TITLE
Use $BT_SCREENS path for screenshots

### DIFF
--- a/bt-iso
+++ b/bt-iso
@@ -371,7 +371,7 @@ if [[ -z "$no_screens" ]]; then
                     --tmpfs /run/lock "$image_name")
     #app_ip=$(podman inspect $app_cont_id --format "{{.NetworkSettings.IPAddress}}")
 
-    export TKL_SCREENSHOT_PATH=$BT_PRODUCTS/$appname/build/screens
+    export TKL_SCREENSHOT_PATH="$BT_SCREENS/$appname"
     mkdir -p "$TKL_SCREENSHOT_PATH"
     SELENIUM_CONT=docker.io/selenium/standalone-chrome
     SELENIUM_TAG=4.18.1-20240224


### PR DESCRIPTION
Save screenshots to `BT_SCREENS/$appname`. `BT_SCREENS` is set in [`config/common.cfg`](https://github.com/turnkeylinux/buildtasks/blob/19.x/config.example/common.cfg#L12).