### PR TITLE
Minor change to fix incorrectly named screenshots & remove unused BT_SCREENS

### DIFF
--- a/bin/iso-release
+++ b/bin/iso-release
@@ -94,7 +94,7 @@ if [[ -e $BT_PROFILES/$appname ]]; then
 fi
 if [[ -z "$no_screens" ]]; then
     mkdir -p "$O/$name.screens"
-    prefix=$(turnkey-version --name --tklversion)
+    prefix=$(turnkey-version --name --tklversion "$rootfs")
     prefix="${prefix/ /-}"
     for screen in build/screens/*.png; do
         screen_file=$(basename "$screen")

--- a/config.example/common.cfg
+++ b/config.example/common.cfg
@@ -9,7 +9,6 @@ export BT_ISOS=/mnt/isos
 export BT_IMGS=/mnt/imgs
 export BT_QEMU=/mnt/qemu
 export BT_BUILDS=/mnt/builds
-export BT_SCREENS=/mnt/screens
 export BT_PROFILES=/turnkey/tklbam-profiles
 export BT_PRODUCTS=/turnkey/fab/products
 


### PR DESCRIPTION
The screenshots all look good and are output to the correct appliance specific dir. However all of them were being named with a 'tkldev-' prefix - instead of the actual appliance name prefix (e.g. 'lamp-').

That's because turnkey-version without a rootfs arg returns info from the host, not the guest. Doh :facepalm: 

Also removed `BT_SCREENS` from `common.cfg` because it's not actually being used. Screenshots are saved in `$BT_ISOS/<app_ver>.screens/` alongside iso related files. E.g. iso related files created with `./bt-iso lamp` (with default `common.cfg` values):

```
/mnt
└── isos
    ├── turnkey-lamp-19.0-trixie-amd64.changelog
    ├── turnkey-lamp-19.0-trixie-amd64.iso
    ├── turnkey-lamp-19.0-trixie-amd64.iso.buildenv
    ├── turnkey-lamp-19.0-trixie-amd64.iso.hash
    ├── turnkey-lamp-19.0-trixie-amd64.log
    ├── turnkey-lamp-19.0-trixie-amd64.manifest
    ├── turnkey-lamp-19.0-trixie-amd64.screens
    │   ├── tkldev-19.0-adminer-database-mysql.png
    │   ├── tkldev-19.0-adminer-frontpage-mysql.png
    │   ├── tkldev-19.0-adminer-login-mysql.png
    │   ├── tkldev-19.0-landing.png
    │   ├── tkldev-19.0-webmin-dashboard.png
    │   ├── tkldev-19.0-webmin-landing-tklbam.png
    │   └── tkldev-19.0-webmin-login.png
    ├── turnkey-lamp-19.0-trixie-amd64.tklbam
    │   └── turnkey-lamp-19.0-trixie-amd64.tar.gz
    ├── turnkey-...
```