### PR TITLE
Destroy/create Selenium container after/before screenshots

### DIFF
--- a/bt-iso
+++ b/bt-iso
@@ -114,6 +114,19 @@ container_status() {
     podman container inspect "$1" --format "{{.State.Status}}"
 }
 
+container_rm() {
+    local cont_name=$1
+    local cont_id=$2
+    info "stopping '$cont_name' container: $(podman stop "$cont_id")"
+    info "removing '$cont_name' container: $(podman rm "$cont_id")"
+}
+
+image_rm() {
+    local cont_name=$1
+    local image_name=$2
+    info "removing '$cont_name' image: $(podman rmi "$image_name")"
+}
+
 check_debug() {
     local msg=$1
     if [[ -z "$DEBUG" ]]; then
@@ -428,8 +441,6 @@ if [[ -z "$no_screens" ]]; then
     existing_id=$(sed -En "s|(^[a-f0-9]+):.*|\1|p" <<<"$existing_instance")
     if [[ -z "$existing_id" ]]; then
         info "no existing selenium container found - starting one"
-        #podman container stop $existing_id >/dev/null 2>&1 || [[ $? -eq 1 ]]
-        #podman container rm $existing_id >/dev/null 2>&1 || [[ $? -eq 1 ]]A
         sel_cont_id=$(podman run -d -p 4444:4444 -p 7900:7900 "$add_hosts" \
                         --shm-size="2g" $SELENIUM_CONT:$SELENIUM_TAG)
     else
@@ -437,10 +448,6 @@ if [[ -z "$no_screens" ]]; then
         info "Assuming it has proper hosts added already (may fail if not)"
         sel_cont_id="$existing_id"
     fi
-    #info "starting new selenium webdriver container (may require download)"
-    #sel_cont_id=$(podman run -d -p 4444:4444 -p 7900:7900 $add_hosts \
-    #                    --shm-size="2g" $SELENIUM_CONT:$SELENIUM_TAG)
-
     info "waiting until container status is 'running'"
     while [[ $(container_status "$sel_cont_id") != "running" ]]; do
         sleep 1
@@ -488,7 +495,7 @@ if [[ -z "$no_screens" ]]; then
         fi
     done
     if [[ ! $exit_code -eq 0 ]]; then
-        warning "Screenshots failed, stopping $appname container: $app_cont_id"
+        warning "Screenshots failed, stopping '$appname' container: $app_cont_id"
         podman stop "$app_cont_id"
         fatal "Screenshots failed after $max_tries attempts - container stopped"
     fi
@@ -505,11 +512,12 @@ if [[ "$publish" == "yes" ]]; then
 fi
 
 if [[ -z "$BT_DEBUG" ]]; then
+    # cleanup & reset ready for next build
     deck -D build/root.sandbox
     make clean
     if [[ -z "$no_screens" ]]; then
-        info "stopping $appname container: $(podman stop "$app_cont_id")"
-        info "removing $appname container: $(podman rm "$app_cont_id")"
-        info "removing $appname image: $(podman rmi "$image_name")"
+        container_rm "$appname" "$image_name"
+        container_rm "selenium" "$sel_cont_id"
+        image_rm "$appname" "$image_name"
     fi
 fi


### PR DESCRIPTION
In theory we should be able to reuse an existing selenium container, but I have hit a few weird issues reusing a container that is already running. I don't recall issues after a stop/start cycle but creating a new container each run gives a "guaranteed" known state. So long as the build server has enough resources It doesn't take long to create a new one each run if the build system has enough resources.

FWIW the thing that takes the most time in the podman/screenshot process is the creation of the test TKL container so destroying/creating a new selenium container is not a huge overhead and ensure a clean screen shot env each time.

Please note this has been tested but may need a tweak...